### PR TITLE
fix: prevent orphaned S3 lock on Ctrl-C by closing heartbeat/release race

### DIFF
--- a/datastore/s3/extensions/datastores/_lib/s3_lock.ts
+++ b/datastore/s3/extensions/datastores/_lib/s3_lock.ts
@@ -91,6 +91,7 @@ export class S3Lock implements DistributedLock {
   private readonly maxWaitMs: number;
   private heartbeatId: number | undefined;
   private held = false;
+  private releasing = false;
   private nonce: string | undefined;
 
   constructor(s3: S3Client, options?: LockOptions) {
@@ -104,6 +105,7 @@ export class S3Lock implements DistributedLock {
 
   async acquire(): Promise<void> {
     const startTime = Date.now();
+    this.releasing = false;
     const nonce = crypto.randomUUID();
 
     while (true) {
@@ -149,6 +151,9 @@ export class S3Lock implements DistributedLock {
   }
 
   async release(): Promise<void> {
+    // Set releasing flag BEFORE stopping heartbeat so any in-flight
+    // extend() sees it and skips writing — prevents orphaned lock files.
+    this.releasing = true;
     this.stopHeartbeat();
 
     if (!this.held) return;
@@ -190,7 +195,7 @@ export class S3Lock implements DistributedLock {
   }
 
   private async extend(): Promise<void> {
-    if (!this.held || !this.nonce) return;
+    if (!this.held || !this.nonce || this.releasing) return;
 
     // Verify we still own the lock before extending (fencing).
     const current = await this.readLock();
@@ -199,6 +204,10 @@ export class S3Lock implements DistributedLock {
       this.stopHeartbeat();
       return;
     }
+
+    // Re-check releasing flag after the async read — release() may have
+    // been called while we were reading the lock.
+    if (this.releasing) return;
 
     const info = buildLockInfo(this.ttlMs, this.nonce);
     const body = encodeLockInfo(info);


### PR DESCRIPTION
## Summary

Applies the same `releasing` flag fix from systeminit/swamp#935 to the S3Lock in the `@swamp/s3-datastore` extension.

**Root cause:** Race condition between the heartbeat `extend()` method and `release()`. When Ctrl-C fires, `release()` deletes the lock, but an in-flight `extend()` can recreate it before the process exits.

**Fix:** Add a `releasing` flag checked by `extend()` between its async read and write — if set, `extend()` returns without writing.

## Test plan

- [x] All 26 existing tests pass (`deno task test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)