### PR TITLE
Add auto-publish workflow for extensions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish Extensions
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  detect-changes:
+    name: Detect changed extensions
+    runs-on: ubuntu-latest
+    outputs:
+      extensions: ${{ steps.changes.outputs.extensions }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: changes
+        name: Find extensions with changes
+        run: |
+          # Compare against the previous commit on main
+          if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            # First push to branch — compare against parent
+            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+          else
+            CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          EXTENSIONS="[]"
+
+          # Find all extension directories (those containing a manifest.yaml)
+          for manifest in $(find . -name "manifest.yaml" -not -path "./.git/*"); do
+            dir=$(dirname "$manifest" | sed 's|^\./||')
+            if echo "$CHANGED_FILES" | grep -q "^${dir}/"; then
+              EXTENSIONS=$(echo "$EXTENSIONS" | jq -c ". + [\"${dir}\"]")
+              echo "Extension changed: ${dir}"
+            fi
+          done
+
+          echo "extensions=$EXTENSIONS" >> "$GITHUB_OUTPUT"
+          echo "Extensions to publish: $EXTENSIONS"
+
+  publish:
+    name: Publish ${{ matrix.extension }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.extensions != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        extension: ${{ fromJson(needs.detect-changes.outputs.extensions) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: systeminit/setup-swamp@v0.1.0
+        with:
+          api-key: ${{ secrets.SWAMP_API_KEY }}
+      - name: Publish extension
+        run: swamp extension push ${{ matrix.extension }}/manifest.yaml


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that automatically publishes extensions when changes are merged to main
- Detects which extensions changed by diffing the merge commit, then publishes only those using `systeminit/setup-swamp@v0.1.0` and `swamp extension push`
- New extensions are auto-discovered via `manifest.yaml` — no workflow changes needed when adding extensions

## Setup required
- Add `SWAMP_API_KEY` as a repository secret

## Test plan
- [ ] Verify `SWAMP_API_KEY` secret is configured
- [ ] Merge this PR and confirm the workflow runs (it won't publish anything since only the workflow file changed)
- [ ] Make a change to an extension and merge — verify it gets published

🤖 Generated with [Claude Code](https://claude.com/claude-code)