### PR TITLE
fix: run swamp extension push from the extension directory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,4 +57,5 @@ jobs:
         with:
           api-key: ${{ secrets.SWAMP_API_KEY }}
       - name: Publish extension
-        run: swamp extension push ${{ matrix.extension }}/manifest.yaml
+        working-directory: ${{ matrix.extension }}
+        run: swamp extension push manifest.yaml


### PR DESCRIPTION
## Summary
- Fix "Not a swamp repository" error in the publish workflow by setting `working-directory` to the extension path so `swamp extension push` runs from within the extension directory where `manifest.yaml` lives.

## Test plan
- [ ] Merge a change to an extension and verify the publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)