### PR TITLE
fix: return file counts from S3 sync pullChanged/pushChanged

### DIFF
--- a/datastore/s3/deno.json
+++ b/datastore/s3/deno.json
@@ -16,6 +16,6 @@
     "@aws-sdk/client-s3": "npm:@aws-sdk/client-s3@3.1010.0",
     "@std/path": "jsr:@std/path@1",
     "@std/fs": "jsr:@std/fs@1",
-    "@systeminit/swamp-testing": "jsr:@systeminit/swamp-testing@0.20260330.3"
+    "@systeminit/swamp-testing": "jsr:@systeminit/swamp-testing@0.20260331.4"
   }
 }

--- a/datastore/s3/deno.lock
+++ b/datastore/s3/deno.lock
@@ -6,7 +6,7 @@
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
-    "jsr:@systeminit/swamp-testing@0.20260330.3": "0.20260330.3",
+    "jsr:@systeminit/swamp-testing@0.20260331.4": "0.20260331.4",
     "npm:@aws-sdk/client-s3@3.1010.0": "3.1010.0",
     "npm:zod@4.3.6": "4.3.6"
   },
@@ -33,8 +33,8 @@
         "jsr:@std/internal"
       ]
     },
-    "@systeminit/swamp-testing@0.20260330.3": {
-      "integrity": "36c7954359acd9281f1f4cd5a2be073954b745e72ef6fb211666b914a47084d0",
+    "@systeminit/swamp-testing@0.20260331.4": {
+      "integrity": "79303614a3743d5041e9c33ac9bf18ff1e3efe2c92cbfac6327f4687f05c2001",
       "dependencies": [
         "jsr:@std/assert"
       ]
@@ -1030,7 +1030,7 @@
     "dependencies": [
       "jsr:@std/fs@1",
       "jsr:@std/path@1",
-      "jsr:@systeminit/swamp-testing@0.20260330.3",
+      "jsr:@systeminit/swamp-testing@0.20260331.4",
       "npm:@aws-sdk/client-s3@3.1010.0",
       "npm:zod@4.3.6"
     ]

--- a/datastore/s3/extensions/datastores/_lib/interfaces.ts
+++ b/datastore/s3/extensions/datastores/_lib/interfaces.ts
@@ -59,8 +59,8 @@ export interface DatastoreVerifier {
 }
 
 export interface DatastoreSyncService {
-  pullChanged(): Promise<void>;
-  pushChanged(): Promise<void>;
+  pullChanged(): Promise<number | void>;
+  pushChanged(): Promise<number | void>;
 }
 
 export interface DatastoreProvider {

--- a/datastore/s3/extensions/datastores/_lib/s3_cache_sync.ts
+++ b/datastore/s3/extensions/datastores/_lib/s3_cache_sync.ts
@@ -143,7 +143,7 @@ export class S3CacheSyncService implements DatastoreSyncService {
    * Fetches the remote index, compares against local files, and only
    * downloads files that are missing locally or have a different size.
    */
-  async pullChanged(): Promise<void> {
+  async pullChanged(): Promise<number | void> {
     await this.pullIndex();
 
     // Build list of files that need pulling
@@ -162,6 +162,7 @@ export class S3CacheSyncService implements DatastoreSyncService {
     }
 
     // Download concurrently in batches
+    let pulled = 0;
     const failedFiles: string[] = [];
     for (let i = 0; i < toPull.length; i += MAX_CONCURRENCY) {
       const batch = toPull.slice(i, i + MAX_CONCURRENCY);
@@ -181,7 +182,9 @@ export class S3CacheSyncService implements DatastoreSyncService {
         }),
       );
       for (let j = 0; j < results.length; j++) {
-        if (results[j].status === "rejected") {
+        if (results[j].status === "fulfilled") {
+          pulled++;
+        } else {
           failedFiles.push(batch[j]);
         }
       }
@@ -194,6 +197,8 @@ export class S3CacheSyncService implements DatastoreSyncService {
         }`,
       );
     }
+
+    return pulled;
   }
 
   /** Pushes a single file from the local cache to S3. */
@@ -218,7 +223,7 @@ export class S3CacheSyncService implements DatastoreSyncService {
    * Pushes only new or modified files from the local cache to S3.
    * Compares each file's size against the index to detect changes.
    */
-  async pushChanged(): Promise<void> {
+  async pushChanged(): Promise<number | void> {
     await this.loadIndex();
 
     // Build list of files that need pushing
@@ -295,6 +300,8 @@ export class S3CacheSyncService implements DatastoreSyncService {
       // Also update the local cache
       await atomicWriteTextFile(this.indexPath, indexJson);
     }
+
+    return pushed;
   }
 
   private async loadIndex(): Promise<void> {

--- a/datastore/s3/manifest.yaml
+++ b/datastore/s3/manifest.yaml
@@ -1,6 +1,6 @@
 manifestVersion: 1
 name: "@swamp/s3-datastore"
-version: "2026.03.31.1"
+version: "2026.03.31.3"
 description: |
   Store data in an Amazon S3 bucket with local cache synchronization.
   Provides distributed locking via S3 conditional writes and bidirectional


### PR DESCRIPTION
Update `S3CacheSyncService` to return actual file counts from `pullChanged()`
and `pushChanged()` instead of `Promise<void>`. This feeds accurate numbers
through to the CLI output — previously `swamp datastore sync --pull` always
displayed "Pulled 0 files" and the coordinator always logged "already up to
date" regardless of how many files were actually transferred.

Companion to systeminit/swamp#977 which updated the `DatastoreSyncService`
interface to accept `Promise<number | void>`.

- **`extensions/datastores/_lib/s3_cache_sync.ts`** — Return pulled/pushed
counts from `pullChanged()` and `pushChanged()`
- **`extensions/datastores/_lib/interfaces.ts`** — Match updated interface
(`Promise<number | void>`)

- Type-checks pass (`deno check`)
- No behavioral change to sync logic — only the return values are new
