### PR TITLE
Add dependency and GitHub Actions audit jobs to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,3 +206,43 @@ jobs:
             git diff --stat
             exit 1
           fi
+
+  deps-audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Scan for known vulnerabilities
+        run: deno run --allow-read --allow-net=api.osv.dev --allow-env=GITHUB_STEP_SUMMARY --allow-write scripts/audit_deps.ts
+      - name: Check for outdated dependencies
+        run: |
+          has_outdated=false
+          for lockdir in $(find vault datastore model codegen -name "deno.lock" -exec dirname {} \;); do
+            output=$(cd "$lockdir" && deno outdated 2>&1) || true
+            if [ -n "$output" ]; then
+              echo "::warning::Outdated dependencies in $lockdir"
+              echo "$output"
+              has_outdated=true
+            fi
+          done
+          if [ "$has_outdated" = false ]; then
+            echo "All dependencies are up to date"
+          fi
+
+  actions-audit:
+    name: Actions Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Check for unpinned or outdated GitHub Actions
+        run: deno run --allow-read --allow-net=api.github.com --allow-env=GITHUB_STEP_SUMMARY,GITHUB_TOKEN --allow-write scripts/audit_actions.ts

--- a/scripts/audit_actions.ts
+++ b/scripts/audit_actions.ts
@@ -1,0 +1,370 @@
+/**
+ * GitHub Actions audit script that checks workflow files for outdated actions
+ * and unpinned references using the GitHub API.
+ *
+ * Reports outdated actions as warnings and unpinned third-party actions
+ * (not using a commit SHA) as errors.
+ *
+ * Exit codes:
+ *   0 - No issues found
+ *   1 - Unpinned third-party actions found
+ */
+
+import { parse as parseYaml } from "jsr:@std/yaml@1";
+
+interface ActionRef {
+  file: string;
+  action: string;
+  owner: string;
+  repo: string;
+  ref: string;
+  isShaPin: boolean;
+  isTrustedPublisher: boolean;
+}
+
+interface TagInfo {
+  latest: string;
+  latestSha: string;
+}
+
+interface AuditFinding {
+  actionRef: ActionRef;
+  kind: "unpinned" | "outdated";
+  detail: string;
+}
+
+/** Publishers whose actions are acceptable with tag-only pins. */
+const TRUSTED_PUBLISHERS = new Set([
+  "actions",
+  "anthropics",
+  "denoland",
+  "docker",
+  "github",
+  "systeminit",
+]);
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+function extractActionRefs(
+  filePath: string,
+  content: string,
+): ActionRef[] {
+  const refs: ActionRef[] = [];
+
+  let workflow: unknown;
+  try {
+    workflow = parseYaml(content);
+  } catch {
+    console.warn(`Warning: could not parse ${filePath}, skipping`);
+    return refs;
+  }
+
+  if (
+    !workflow || typeof workflow !== "object" ||
+    !("jobs" in workflow) || typeof workflow.jobs !== "object" ||
+    !workflow.jobs
+  ) {
+    return refs;
+  }
+
+  for (const job of Object.values(workflow.jobs)) {
+    const steps = (job as Record<string, unknown>)?.steps;
+    if (!Array.isArray(steps)) continue;
+
+    for (const step of steps) {
+      const uses = step?.uses;
+      if (typeof uses !== "string") continue;
+
+      // Skip Docker and local actions
+      if (uses.startsWith("docker://") || uses.startsWith("./")) continue;
+
+      // Parse owner/repo@ref
+      const atIndex = uses.indexOf("@");
+      if (atIndex === -1) continue;
+
+      const actionPath = uses.substring(0, atIndex);
+      const ref = uses.substring(atIndex + 1);
+      const slashIndex = actionPath.indexOf("/");
+      if (slashIndex === -1) continue;
+
+      const owner = actionPath.substring(0, slashIndex);
+      const repo = actionPath.substring(slashIndex + 1);
+
+      refs.push({
+        file: filePath,
+        action: `${owner}/${repo}`,
+        owner,
+        repo,
+        ref,
+        isShaPin: SHA_PATTERN.test(ref),
+        isTrustedPublisher: TRUSTED_PUBLISHERS.has(owner),
+      });
+    }
+  }
+
+  return refs;
+}
+
+function apiHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Accept": "application/vnd.github+json",
+    "User-Agent": "swamp-extensions-audit-actions",
+  };
+  const token = Deno.env.get("GITHUB_TOKEN");
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+/** Resolve a git ref to a commit SHA, dereferencing annotated tags if needed. */
+async function resolveCommitSha(
+  owner: string,
+  repo: string,
+  refData: { sha: string; type: string },
+): Promise<string> {
+  if (refData.type !== "tag") return refData.sha;
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/git/tags/${refData.sha}`,
+      { headers: apiHeaders() },
+    );
+    if (response.ok) {
+      const tag = await response.json();
+      return tag.object?.sha ?? refData.sha;
+    }
+  } catch {
+    // Fall back to the tag object SHA
+  }
+  return refData.sha;
+}
+
+async function getLatestTag(
+  owner: string,
+  repo: string,
+): Promise<TagInfo | null> {
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/releases/latest`,
+      { headers: apiHeaders() },
+    );
+
+    if (response.ok) {
+      const release = await response.json();
+      const tagName = release.tag_name;
+
+      const tagResponse = await fetch(
+        `https://api.github.com/repos/${owner}/${repo}/git/ref/tags/${tagName}`,
+        { headers: apiHeaders() },
+      );
+
+      if (tagResponse.ok) {
+        const tagData = await tagResponse.json();
+        const commitSha = await resolveCommitSha(
+          owner,
+          repo,
+          tagData.object,
+        );
+        return { latest: tagName, latestSha: commitSha };
+      }
+
+      return { latest: tagName, latestSha: "" };
+    }
+  } catch {
+    // Fall through to tags API
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/tags?per_page=1`,
+      { headers: apiHeaders() },
+    );
+
+    if (response.ok) {
+      const tags = await response.json();
+      if (tags.length > 0) {
+        return { latest: tags[0].name, latestSha: tags[0].commit.sha };
+      }
+    }
+  } catch {
+    // Couldn't reach API
+  }
+
+  return null;
+}
+
+/** Check if a tag ref (e.g., "v3") is a major version prefix of the latest tag. */
+function isSameMajor(currentRef: string, latestTag: string): boolean {
+  const current = currentRef.replace(/^v/, "");
+  const latest = latestTag.replace(/^v/, "");
+
+  const currentMajor = current.split(".")[0];
+  const latestMajor = latest.split(".")[0];
+
+  return currentMajor === latestMajor;
+}
+
+async function writeGitHubSummary(findings: AuditFinding[]): Promise<void> {
+  const summaryFile = Deno.env.get("GITHUB_STEP_SUMMARY");
+  if (!summaryFile) return;
+
+  const lines: string[] = ["## GitHub Actions Audit Results\n"];
+
+  const unpinned = findings.filter((f) => f.kind === "unpinned");
+  const outdated = findings.filter((f) => f.kind === "outdated");
+
+  if (unpinned.length > 0) {
+    lines.push("### Unpinned Third-Party Actions\n");
+    lines.push(
+      "These actions are not pinned to a commit SHA and could be modified without your knowledge.\n",
+    );
+    for (const { actionRef, detail } of unpinned) {
+      lines.push(
+        `- \`${actionRef.action}@${actionRef.ref}\` in \`${actionRef.file}\`: ${detail}`,
+      );
+    }
+    lines.push("");
+  }
+
+  if (outdated.length > 0) {
+    lines.push("### Outdated Actions\n");
+    lines.push(
+      "> **Warning**: These actions have newer versions available.\n",
+    );
+    for (const { actionRef, detail } of outdated) {
+      lines.push(
+        `- \`${actionRef.action}@${actionRef.ref}\` in \`${actionRef.file}\`: ${detail}`,
+      );
+    }
+    lines.push("");
+  }
+
+  if (findings.length === 0) {
+    lines.push("All GitHub Actions references are up to date and pinned.");
+  }
+
+  await Deno.writeTextFile(summaryFile, lines.join("\n"));
+}
+
+async function main(): Promise<void> {
+  const workflowDir = ".github/workflows";
+  const refs: ActionRef[] = [];
+
+  try {
+    for await (const entry of Deno.readDir(workflowDir)) {
+      if (
+        !entry.isFile ||
+        (!entry.name.endsWith(".yml") && !entry.name.endsWith(".yaml"))
+      ) {
+        continue;
+      }
+
+      const filePath = `${workflowDir}/${entry.name}`;
+      const content = await Deno.readTextFile(filePath);
+      refs.push(...extractActionRefs(filePath, content));
+    }
+  } catch {
+    console.error(`Error: could not read ${workflowDir}`);
+    Deno.exit(1);
+  }
+
+  if (refs.length === 0) {
+    console.log("No action references found in workflow files.");
+    Deno.exit(0);
+  }
+
+  // Deduplicate by action+ref for API calls
+  const uniqueActions = new Map<string, ActionRef>();
+  for (const ref of refs) {
+    const key = `${ref.action}@${ref.ref}`;
+    if (!uniqueActions.has(key)) {
+      uniqueActions.set(key, ref);
+    }
+  }
+
+  console.log(
+    `Checking ${uniqueActions.size} unique action references across ${refs.length} usages…`,
+  );
+
+  const findings: AuditFinding[] = [];
+
+  // Check unpinned third-party actions
+  for (const [, actionRef] of uniqueActions) {
+    if (!actionRef.isShaPin && !actionRef.isTrustedPublisher) {
+      findings.push({
+        actionRef,
+        kind: "unpinned",
+        detail:
+          `Third-party action not pinned to a commit SHA. Pin to a full SHA for supply chain security.`,
+      });
+    }
+  }
+
+  // Check for outdated versions in parallel
+  const versionChecks = [...uniqueActions.values()].map(async (actionRef) => {
+    const tagInfo = await getLatestTag(actionRef.owner, actionRef.repo);
+    if (!tagInfo) return;
+
+    if (actionRef.isShaPin) {
+      if (tagInfo.latestSha && actionRef.ref !== tagInfo.latestSha) {
+        findings.push({
+          actionRef,
+          kind: "outdated",
+          detail: `Pinned SHA does not match latest release ${tagInfo.latest}`,
+        });
+      }
+    } else {
+      if (!isSameMajor(actionRef.ref, tagInfo.latest)) {
+        findings.push({
+          actionRef,
+          kind: "outdated",
+          detail: `Using ${actionRef.ref}, latest is ${tagInfo.latest}`,
+        });
+      }
+    }
+  });
+
+  await Promise.all(versionChecks);
+
+  // Write GitHub Actions job summary
+  await writeGitHubSummary(findings);
+
+  const unpinned = findings.filter((f) => f.kind === "unpinned");
+  const outdated = findings.filter((f) => f.kind === "outdated");
+
+  if (findings.length === 0) {
+    console.log("All action references are up to date and properly pinned.");
+    Deno.exit(0);
+  }
+
+  if (unpinned.length > 0) {
+    console.error(
+      `\nUnpinned third-party actions (${unpinned.length}):\n`,
+    );
+    for (const { actionRef, detail } of unpinned) {
+      console.error(
+        `  ${actionRef.action}@${actionRef.ref} (${actionRef.file})`,
+      );
+      console.error(`    ${detail}`);
+    }
+  }
+
+  if (outdated.length > 0) {
+    const label = outdated.length === 1 ? "action" : "actions";
+    console.warn(
+      `\nOutdated ${label} (${outdated.length}):\n`,
+    );
+    for (const { actionRef, detail } of outdated) {
+      console.warn(
+        `  ${actionRef.action}@${actionRef.ref} (${actionRef.file})`,
+      );
+      console.warn(`    ${detail}`);
+    }
+  }
+
+  // Fail on unpinned third-party actions
+  Deno.exit(unpinned.length > 0 ? 1 : 0);
+}
+
+main();

--- a/scripts/audit_deps.ts
+++ b/scripts/audit_deps.ts
@@ -1,0 +1,405 @@
+/**
+ * Dependency audit script that checks npm packages in all deno.lock files
+ * for known vulnerabilities using the OSV.dev API (https://osv.dev/).
+ *
+ * Discovers deno.lock files by walking vault/, datastore/, model/, and codegen/
+ * directories — no hardcoded list, so new extensions are picked up automatically.
+ *
+ * Direct dependency vulnerabilities fail the build. Transitive dependency
+ * vulnerabilities are reported as warnings with their full dependency chain.
+ *
+ * Exit codes:
+ *   0 - No direct dependency vulnerabilities found
+ *   1 - Direct dependency vulnerabilities found
+ */
+
+interface NpmEntry {
+  integrity: string;
+  dependencies?: string[];
+}
+
+interface DenoLock {
+  version: string;
+  specifiers?: Record<string, string>;
+  npm?: Record<string, NpmEntry>;
+}
+
+interface OsvVulnerability {
+  id: string;
+  summary?: string;
+  severity?: Array<{ type: string; score: string }>;
+  aliases?: string[];
+}
+
+interface OsvResult {
+  vulns?: OsvVulnerability[];
+}
+
+interface OsvBatchResponse {
+  results: OsvResult[];
+}
+
+interface PackageInfo {
+  name: string;
+  version: string;
+  isDirect: boolean;
+}
+
+interface VulnFinding {
+  lockfile: string;
+  pkg: PackageInfo;
+  vulns: OsvVulnerability[];
+  chain: string[];
+}
+
+/** Directories to scan for deno.lock files. */
+const SCAN_ROOTS = ["vault", "datastore", "model", "codegen"];
+
+/**
+ * Recursively discover all deno.lock files under the given root directories.
+ */
+async function discoverLockfiles(roots: string[]): Promise<string[]> {
+  const lockfiles: string[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    try {
+      for await (const entry of Deno.readDir(dir)) {
+        const path = `${dir}/${entry.name}`;
+        if (entry.isFile && entry.name === "deno.lock") {
+          lockfiles.push(path);
+        } else if (entry.isDirectory && !entry.name.startsWith(".")) {
+          await walk(path);
+        }
+      }
+    } catch {
+      // Directory doesn't exist yet — skip
+    }
+  }
+
+  for (const root of roots) {
+    await walk(root);
+  }
+
+  return lockfiles.sort();
+}
+
+/**
+ * Build a map from package name to the full key(s) in the npm section.
+ */
+function buildNameToKeyMap(
+  npm: Record<string, NpmEntry>,
+): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const key of Object.keys(npm)) {
+    const lastAt = key.lastIndexOf("@");
+    if (lastAt <= 0) continue;
+    const name = key.substring(0, lastAt);
+    const existing = map.get(name) ?? [];
+    existing.push(key);
+    map.set(name, existing);
+  }
+  return map;
+}
+
+/**
+ * Build a reverse dependency graph: for each package key, which other
+ * package keys depend on it?
+ */
+function buildReverseDeps(
+  npm: Record<string, NpmEntry>,
+  nameToKeys: Map<string, string[]>,
+): Map<string, string[]> {
+  const reverseDeps = new Map<string, string[]>();
+
+  for (const [parentKey, entry] of Object.entries(npm)) {
+    for (const depName of entry.dependencies ?? []) {
+      const depKeys = nameToKeys.get(depName) ?? [];
+      for (const depKey of depKeys) {
+        const parents = reverseDeps.get(depKey) ?? [];
+        parents.push(parentKey);
+        reverseDeps.set(depKey, parents);
+      }
+    }
+  }
+
+  return reverseDeps;
+}
+
+/**
+ * Trace the dependency chain from a vulnerable package back to a direct
+ * dependency using BFS on the reverse dependency graph.
+ */
+function traceDependencyChain(
+  targetKey: string,
+  reverseDeps: Map<string, string[]>,
+  directNames: Set<string>,
+): string[] {
+  const visited = new Set<string>();
+  const queue: Array<{ key: string; path: string[] }> = [
+    { key: targetKey, path: [targetKey] },
+  ];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current.key)) continue;
+    visited.add(current.key);
+
+    const lastAt = current.key.lastIndexOf("@");
+    if (lastAt > 0) {
+      const name = current.key.substring(0, lastAt);
+      if (directNames.has(name) && current.path.length > 1) {
+        return current.path.reverse();
+      }
+    }
+
+    const parents = reverseDeps.get(current.key) ?? [];
+    for (const parent of parents) {
+      if (!visited.has(parent)) {
+        queue.push({ key: parent, path: [...current.path, parent] });
+      }
+    }
+  }
+
+  return [targetKey];
+}
+
+function parseNpmPackages(
+  lockData: DenoLock,
+): { packages: PackageInfo[]; directNames: Set<string> } {
+  const npm = lockData.npm;
+  if (!npm) return { packages: [], directNames: new Set() };
+
+  const directNames = new Set<string>();
+  for (const key of Object.keys(lockData.specifiers ?? {})) {
+    if (key.startsWith("npm:")) {
+      const withoutPrefix = key.substring(4);
+      const lastAt = withoutPrefix.lastIndexOf("@");
+      if (lastAt > 0) {
+        directNames.add(withoutPrefix.substring(0, lastAt));
+      }
+    }
+  }
+
+  const packages: PackageInfo[] = [];
+  for (const key of Object.keys(npm)) {
+    const lastAt = key.lastIndexOf("@");
+    if (lastAt <= 0) continue;
+
+    const name = key.substring(0, lastAt);
+    const rawVersion = key.substring(lastAt + 1);
+    const version = rawVersion.split("_")[0];
+
+    packages.push({ name, version, isDirect: directNames.has(name) });
+  }
+
+  return { packages, directNames };
+}
+
+async function queryOsv(
+  packages: PackageInfo[],
+): Promise<OsvBatchResponse> {
+  const queries = packages.map((pkg) => ({
+    package: { name: pkg.name, ecosystem: "npm" },
+    version: pkg.version,
+  }));
+
+  const response = await fetch("https://api.osv.dev/v1/querybatch", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ queries }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `OSV API returned ${response.status}: ${await response.text()}`,
+    );
+  }
+
+  return await response.json() as OsvBatchResponse;
+}
+
+function formatVuln(vuln: OsvVulnerability): string {
+  const aliases = vuln.aliases?.filter((a) => a.startsWith("CVE-")) ?? [];
+  const cve = aliases.length > 0 ? ` (${aliases.join(", ")})` : "";
+  const summary = vuln.summary ?? "No description available";
+  return `${vuln.id}${cve}: ${summary}`;
+}
+
+function formatChain(chain: string[]): string {
+  if (chain.length <= 1) return "";
+  return chain.join(" → ");
+}
+
+async function writeGitHubSummary(
+  direct: VulnFinding[],
+  transitive: VulnFinding[],
+): Promise<void> {
+  const summaryFile = Deno.env.get("GITHUB_STEP_SUMMARY");
+  if (!summaryFile) return;
+
+  const lines: string[] = ["## Dependency Audit Results\n"];
+
+  if (direct.length > 0) {
+    lines.push("### Direct Dependency Vulnerabilities\n");
+    lines.push(
+      "These are in packages you directly depend on and **must be resolved**.\n",
+    );
+    for (const { lockfile, pkg, vulns } of direct) {
+      lines.push(`#### \`${pkg.name}@${pkg.version}\` in \`${lockfile}\`\n`);
+      for (const vuln of vulns) {
+        lines.push(`- ${formatVuln(vuln)}`);
+      }
+      lines.push("");
+    }
+  }
+
+  if (transitive.length > 0) {
+    lines.push("### Transitive Dependency Vulnerabilities\n");
+    lines.push(
+      "> **Warning**: These are in upstream transitive dependencies. ",
+    );
+    lines.push(
+      "They require fixes from upstream maintainers and do not block this build.\n",
+    );
+    for (const { lockfile, pkg, vulns, chain } of transitive) {
+      lines.push(`#### \`${pkg.name}@${pkg.version}\` in \`${lockfile}\`\n`);
+      if (chain.length > 1) {
+        lines.push(`Dependency chain: \`${formatChain(chain)}\`\n`);
+      }
+      for (const vuln of vulns) {
+        lines.push(`- ${formatVuln(vuln)}`);
+      }
+      lines.push("");
+    }
+  }
+
+  if (direct.length === 0 && transitive.length === 0) {
+    lines.push("No known vulnerabilities found.");
+  }
+
+  await Deno.writeTextFile(summaryFile, lines.join("\n"));
+}
+
+async function auditLockfile(
+  lockfilePath: string,
+): Promise<{ direct: VulnFinding[]; transitive: VulnFinding[] }> {
+  const lockContent = await Deno.readTextFile(lockfilePath);
+  const lockData = JSON.parse(lockContent) as DenoLock;
+  const { packages, directNames } = parseNpmPackages(lockData);
+
+  if (packages.length === 0) {
+    return { direct: [], transitive: [] };
+  }
+
+  console.log(
+    `  ${lockfilePath}: scanning ${packages.length} npm packages…`,
+  );
+
+  const npm = lockData.npm ?? {};
+  const nameToKeys = buildNameToKeyMap(npm);
+  const reverseDeps = buildReverseDeps(npm, nameToKeys);
+
+  const direct: VulnFinding[] = [];
+  const transitive: VulnFinding[] = [];
+
+  const batchSize = 1000;
+  for (let i = 0; i < packages.length; i += batchSize) {
+    const batch = packages.slice(i, i + batchSize);
+    const response = await queryOsv(batch);
+
+    for (let j = 0; j < response.results.length; j++) {
+      const result = response.results[j];
+      if (result.vulns && result.vulns.length > 0) {
+        const pkg = batch[j];
+        const targetKey = `${pkg.name}@${pkg.version}`;
+        const chain = pkg.isDirect
+          ? [targetKey]
+          : traceDependencyChain(targetKey, reverseDeps, directNames);
+        const finding = {
+          lockfile: lockfilePath,
+          pkg,
+          vulns: result.vulns,
+          chain,
+        };
+
+        if (pkg.isDirect) {
+          direct.push(finding);
+        } else {
+          transitive.push(finding);
+        }
+      }
+    }
+  }
+
+  return { direct, transitive };
+}
+
+async function main(): Promise<void> {
+  const lockfiles = await discoverLockfiles(SCAN_ROOTS);
+
+  if (lockfiles.length === 0) {
+    console.error("No deno.lock files found.");
+    Deno.exit(1);
+  }
+
+  console.log(`Found ${lockfiles.length} lockfiles to audit:`);
+  for (const lf of lockfiles) {
+    console.log(`  ${lf}`);
+  }
+  console.log("");
+
+  const allDirect: VulnFinding[] = [];
+  const allTransitive: VulnFinding[] = [];
+
+  for (const lockfile of lockfiles) {
+    const { direct, transitive } = await auditLockfile(lockfile);
+    allDirect.push(...direct);
+    allTransitive.push(...transitive);
+  }
+
+  await writeGitHubSummary(allDirect, allTransitive);
+
+  if (allDirect.length === 0 && allTransitive.length === 0) {
+    console.log("\nNo known vulnerabilities found.");
+    Deno.exit(0);
+  }
+
+  if (allDirect.length > 0) {
+    console.error(
+      `\nDirect dependency vulnerabilities (${allDirect.length} finding(s)):\n`,
+    );
+    for (const { lockfile, pkg, vulns } of allDirect) {
+      console.error(`  ${pkg.name}@${pkg.version} (${lockfile})`);
+      for (const vuln of vulns) {
+        console.error(`    - ${formatVuln(vuln)}`);
+      }
+      console.error("");
+    }
+  }
+
+  if (allTransitive.length > 0) {
+    const label = allTransitive.length === 1 ? "finding" : "findings";
+    console.warn(
+      `\nTransitive dependency vulnerabilities (${allTransitive.length} ${label} — warning only):\n`,
+    );
+    for (const { lockfile, pkg, vulns, chain } of allTransitive) {
+      console.warn(`  ${pkg.name}@${pkg.version} (${lockfile})`);
+      if (chain.length > 1) {
+        console.warn(`    chain: ${formatChain(chain)}`);
+      }
+      for (const vuln of vulns) {
+        console.warn(`    - ${formatVuln(vuln)}`);
+      }
+      console.warn("");
+    }
+    if (allDirect.length === 0) {
+      console.warn(
+        "Transitive vulnerabilities require upstream fixes and do not fail this check.",
+      );
+    }
+  }
+
+  Deno.exit(allDirect.length > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
- Add scripts/audit_deps.ts that discovers all deno.lock files dynamically across vault/, datastore/, model/, and codegen/
directories and scans npm packages against OSV.dev for known vulnerabilities. Direct dependency vulns fail the build;
transitive ones warn with full dependency chain tracing.
- Add scripts/audit_actions.ts that scans workflow files for unpinned third-party actions (fails build) and outdated actions
(warns). Trusted publishers (actions, anthropics, denoland, docker, github, systeminit) are allowed to use tag-only pins.
- Add deps-audit and actions-audit jobs to CI workflow with minimal permissions (contents: read).

- No hardcoded extension lists — both the audit script and the deno outdated step discover lockfiles by walking the
directory tree, so new extensions are picked up automatically.
- Adapted from systeminit/swamp — same patterns as the main repo's audit_deps.ts and audit_actions.ts, with key differences:
multi-lockfile support for the monorepo structure, systeminit added to trusted publishers, and unpinned third-party actions
fail the build (not just warn).
- Transitive vulns don't block — they require upstream fixes, so they're reported as warnings with the full dependency chain
to aid triage.

- deno check passes on both scripts
- deno lint and deno fmt --check pass
- audit_deps.ts discovers all 8 lockfiles and scans 239 packages successfully
- audit_actions.ts finds 3 unique actions across 25 usages, all passing
