### PR TITLE
Fix publish repo detection and update code review prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,15 +444,21 @@ jobs:
             Then read every changed file in this PR thoroughly.
 
             IMPORTANT: Files under `model/` are auto-generated — do NOT review their content.
-            Skip reading files in `model/`. Instead, if a PR modifies files in `model/` without
-            also modifying `codegen/`, flag that as a blocking issue (it means someone hand-edited
-            generated code). Focus your review on `vault/`, `datastore/`, `codegen/`, and `scripts/`.
+            Skip reading files in `model/`. Focus your review on `vault/`, `datastore/`, `codegen/`,
+            and `scripts/`.
+
+            Model files may change without codegen changes in two legitimate cases:
+            1. Codegen regeneration (codegen/ also changes)
+            2. Version bumps via `bump-versions` script (only version, upgrades, and manifest change)
+            If model files have changes beyond version/upgrade entries and no codegen/ changes exist,
+            flag that as a blocking issue (hand-edited generated code).
 
             Review this PR for:
 
             ## 1. CLAUDE.md Compliance
             - Files under `model/` must NEVER be hand-edited. If this PR modifies files in `model/`
-              without corresponding changes in `codegen/`, that is a blocking issue.
+              with changes beyond version/upgrade entries and no corresponding `codegen/` changes,
+              that is a blocking issue.
             - No `any` types in hand-written code (generated code may use `any`).
             - Named exports only, no default exports.
             - All npm dependencies must be pinned to exact versions (no semver ranges like ^ or ~).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,9 @@ jobs:
               continue
             fi
 
-            if [ ! -d .swamp ]; then
+            # Ensure a swamp repo marker exists (auto-generated model
+            # directories don't have .swamp.yaml committed)
+            if [ ! -f .swamp.yaml ]; then
               swamp repo init --quiet --tool none
             fi
 


### PR DESCRIPTION
## Summary
- **publish.yml**: Fix `.swamp` directory check to `.swamp.yaml` file check. Auto-generated model directories (AWS/GCP) don't have `.swamp.yaml` committed — the publish job now inits a swamp repo when the marker file is missing, matching how vault/datastore extensions work.
- **ci.yml**: Update the Claude code review prompt to recognize version bump PRs as legitimate. Model files may change without codegen changes when the `bump-versions` script runs (only version, upgrade entries, and manifests change). Previously, the review would flag these as hand-edited generated code.

## Test plan
- [ ] Publish job succeeds for AWS/GCP model extensions (no "Not a swamp repository" error)
- [ ] Code review approves PRs that only bump model versions/upgrades without codegen changes
- [ ] Code review still blocks PRs that hand-edit model files beyond version/upgrade entries