### PR TITLE
Use GH_TOKEN PAT for regenerate-models workflow

### DIFF
--- a/.github/workflows/regenerate-models.yml
+++ b/.github/workflows/regenerate-models.yml
@@ -32,6 +32,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       - uses: denoland/setup-deno@v2
         with:
@@ -139,7 +141,7 @@ jobs:
       - name: Create or update pull request
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           CHANGE_SUMMARY: ${{ steps.changes.outputs.summary }}
         run: |
           BRANCH="automated/regenerate-models"
@@ -182,10 +184,6 @@ jobs:
           - CalVer versioning with content-based change detection ensures versions only bump when content changes
           - Publishing happens automatically when this PR is merged (via the publish workflow)
 
-          > [!NOTE]
-          > If CI does not trigger on this PR, close and reopen it, or configure a
-          > GitHub App token for the workflow. PRs created by \`GITHUB_TOKEN\` do not
-          > trigger other workflow runs.
           EOF
 
             gh pr create \


### PR DESCRIPTION
## Summary

- Use `secrets.GH_TOKEN` (a PAT) instead of `GITHUB_TOKEN` for checkout and PR creation in the regenerate-models workflow
- PRs created by `GITHUB_TOKEN` don't trigger downstream workflow runs (like CI); a PAT doesn't have this limitation

## Test plan

- [ ] Verify `GH_TOKEN` secret is configured in the repo
- [ ] Trigger the regenerate-models workflow manually and confirm the created PR triggers CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)