### PR TITLE
chore: regenerate models from upstream schemas

### DIFF
--- a/model/aws/apigatewayv2/extensions/models/stage.ts
+++ b/model/aws/apigatewayv2/extensions/models/stage.ts
@@ -1,0 +1,299 @@
+// Auto-generated extension model for @swamp/aws/apigatewayv2/stage
+// Do not edit manually. Re-generate with: deno task generate:aws
+
+// deno-lint-ignore-file no-explicit-any
+
+import { z } from "zod";
+import {
+  createResource,
+  deleteResource,
+  isResourceNotFoundError,
+  readResource,
+  updateResource,
+} from "./_lib/aws.ts";
+
+const GlobalArgsSchema = z.object({
+  name: z.string().describe(
+    "Instance name for this resource (used as the unique identifier in the factory pattern)",
+  ),
+  ClientCertificateId: z.string().describe(
+    "The identifier of a client certificate for a Stage. Supported only for WebSocket APIs.",
+  ).optional(),
+  DeploymentId: z.string().describe(
+    "The deployment identifier for the API stage. Can't be updated if autoDeploy is enabled.",
+  ).optional(),
+  Description: z.string().describe("The description for the API stage.")
+    .optional(),
+  AutoDeploy: z.boolean().describe(
+    "Specifies whether updates to an API automatically trigger a new deployment. The default value is false.",
+  ).optional(),
+  AccessLogSettings: z.object({
+    Format: z.string().optional(),
+    DestinationArn: z.string().optional(),
+  }).describe("Settings for logging access in this stage.").optional(),
+  RouteSettings: z.string().describe("Route settings for the stage.")
+    .optional(),
+  StageName: z.string().describe(
+    "The stage name. Stage names can contain only alphanumeric characters, hyphens, and underscores, or be $default. Maximum length is 128 characters.",
+  ),
+  StageVariables: z.string().describe(
+    "A map that defines the stage variables for a Stage. Variable names can have alphanumeric and underscore characters, and the values must match [A-Za-z0-9-._~:/?#&=,]+.",
+  ).optional(),
+  ApiId: z.string().describe("The API identifier."),
+  DefaultRouteSettings: z.object({
+    LoggingLevel: z.string().optional(),
+    DataTraceEnabled: z.boolean().optional(),
+    ThrottlingBurstLimit: z.number().int().optional(),
+    DetailedMetricsEnabled: z.boolean().optional(),
+    ThrottlingRateLimit: z.number().optional(),
+  }).describe("The default route settings for the stage.").optional(),
+  Tags: z.string().describe(
+    "The collection of tags. Each tag element is associated with a given resource.",
+  ).optional(),
+});
+
+const StateSchema = z.object({
+  ClientCertificateId: z.string().optional(),
+  DeploymentId: z.string().optional(),
+  Description: z.string().optional(),
+  AutoDeploy: z.boolean().optional(),
+  AccessLogSettings: z.object({
+    Format: z.string(),
+    DestinationArn: z.string(),
+  }).optional(),
+  RouteSettings: z.string().optional(),
+  StageName: z.string(),
+  StageVariables: z.string().optional(),
+  ApiId: z.string(),
+  DefaultRouteSettings: z.object({
+    LoggingLevel: z.string(),
+    DataTraceEnabled: z.boolean(),
+    ThrottlingBurstLimit: z.number(),
+    DetailedMetricsEnabled: z.boolean(),
+    ThrottlingRateLimit: z.number(),
+  }).optional(),
+  Tags: z.string().optional(),
+}).passthrough();
+
+type StateData = z.infer<typeof StateSchema>;
+
+const InputsSchema = z.object({
+  name: z.string().optional(),
+  ClientCertificateId: z.string().describe(
+    "The identifier of a client certificate for a Stage. Supported only for WebSocket APIs.",
+  ).optional(),
+  DeploymentId: z.string().describe(
+    "The deployment identifier for the API stage. Can't be updated if autoDeploy is enabled.",
+  ).optional(),
+  Description: z.string().describe("The description for the API stage.")
+    .optional(),
+  AutoDeploy: z.boolean().describe(
+    "Specifies whether updates to an API automatically trigger a new deployment. The default value is false.",
+  ).optional(),
+  AccessLogSettings: z.object({
+    Format: z.string().optional(),
+    DestinationArn: z.string().optional(),
+  }).describe("Settings for logging access in this stage.").optional(),
+  RouteSettings: z.string().describe("Route settings for the stage.")
+    .optional(),
+  StageName: z.string().describe(
+    "The stage name. Stage names can contain only alphanumeric characters, hyphens, and underscores, or be $default. Maximum length is 128 characters.",
+  ).optional(),
+  StageVariables: z.string().describe(
+    "A map that defines the stage variables for a Stage. Variable names can have alphanumeric and underscore characters, and the values must match [A-Za-z0-9-._~:/?#&=,]+.",
+  ).optional(),
+  ApiId: z.string().describe("The API identifier.").optional(),
+  DefaultRouteSettings: z.object({
+    LoggingLevel: z.string().optional(),
+    DataTraceEnabled: z.boolean().optional(),
+    ThrottlingBurstLimit: z.number().int().optional(),
+    DetailedMetricsEnabled: z.boolean().optional(),
+    ThrottlingRateLimit: z.number().optional(),
+  }).describe("The default route settings for the stage.").optional(),
+  Tags: z.string().describe(
+    "The collection of tags. Each tag element is associated with a given resource.",
+  ).optional(),
+});
+
+export const model = {
+  type: "@swamp/aws/apigatewayv2/stage",
+  version: "2026.04.03.1",
+  globalArguments: GlobalArgsSchema,
+  inputsSchema: InputsSchema,
+  resources: {
+    state: {
+      description: "ApiGatewayV2 Stage resource state",
+      schema: StateSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    create: {
+      description: "Create a ApiGatewayV2 Stage",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const desiredState: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(g)) {
+          if (key === "name") continue;
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await createResource(
+          "AWS::ApiGatewayV2::Stage",
+          desiredState,
+        ) as StateData;
+        const instanceName = g.name?.toString() ?? "current";
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    get: {
+      description: "Get a ApiGatewayV2 Stage",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the ApiGatewayV2 Stage",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const result = await readResource(
+          "AWS::ApiGatewayV2::Stage",
+          args.identifier,
+        ) as StateData;
+        const instanceName = context.globalArgs.name?.toString() ??
+          args.identifier;
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    update: {
+      description: "Update a ApiGatewayV2 Stage",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = g.name?.toString() ?? "current";
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const idParts = [
+          existing.ApiId?.toString(),
+          existing.StageName?.toString(),
+        ];
+        if (idParts.some((p) => !p)) {
+          throw new Error(
+            "Missing primary identifier fields in existing state",
+          );
+        }
+        const identifier = idParts.join("|");
+        const currentState = await readResource(
+          "AWS::ApiGatewayV2::Stage",
+          identifier,
+        ) as StateData;
+        const desiredState: Record<string, unknown> = { ...currentState };
+        for (const [key, value] of Object.entries(g)) {
+          if (key === "name") continue;
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await updateResource(
+          "AWS::ApiGatewayV2::Stage",
+          identifier,
+          currentState,
+          desiredState,
+          ["StageName", "ApiId"],
+        );
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    delete: {
+      description: "Delete a ApiGatewayV2 Stage",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the ApiGatewayV2 Stage",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const { existed } = await deleteResource(
+          "AWS::ApiGatewayV2::Stage",
+          args.identifier,
+        );
+        const instanceName = context.globalArgs.name?.toString() ??
+          args.identifier;
+        const handle = await context.writeResource("state", instanceName, {
+          identifier: args.identifier,
+          existed,
+          status: existed ? "deleted" : "not_found",
+          deletedAt: new Date().toISOString(),
+        });
+        return { dataHandles: [handle] };
+      },
+    },
+    sync: {
+      description: "Sync ApiGatewayV2 Stage state from AWS",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = g.name?.toString() ?? "current";
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const idParts = [
+          existing.ApiId?.toString(),
+          existing.StageName?.toString(),
+        ];
+        if (idParts.some((p) => !p)) {
+          throw new Error(
+            "Missing primary identifier fields in existing state",
+          );
+        }
+        const identifier = idParts.join("|");
+        try {
+          const result = await readResource(
+            "AWS::ApiGatewayV2::Stage",
+            identifier,
+          ) as StateData;
+          const handle = await context.writeResource(
+            "state",
+            instanceName,
+            result,
+          );
+          return { dataHandles: [handle] };
+        } catch (error: unknown) {
+          if (isResourceNotFoundError(error)) {
+            const handle = await context.writeResource("state", instanceName, {
+              identifier,
+              status: "not_found",
+              syncedAt: new Date().toISOString(),
+            });
+            return { dataHandles: [handle] };
+          }
+          throw error;
+        }
+      },
+    },
+  },
+};

--- a/model/aws/apigatewayv2/manifest.yaml
+++ b/model/aws/apigatewayv2/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/apigatewayv2"
-version: "2026.04.01.1"
+version: "2026.04.03.1"
 description: "AWS APIGATEWAYV2 infrastructure models"
 labels:
   - aws
@@ -9,7 +9,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: api, api_mapping, authorizer, deployment, domain_name, integration, integration_response, model, route, route_response, routing_rule, vpc_link
+  - Added: stage
 models:
   - api.ts
   - api_mapping.ts
@@ -22,6 +22,7 @@ models:
   - route.ts
   - route_response.ts
   - routing_rule.ts
+  - stage.ts
   - vpc_link.ts
 additionalFiles:
   - LICENSE.txt

--- a/model/aws/appsync/extensions/models/graph_qlapi.ts
+++ b/model/aws/appsync/extensions/models/graph_qlapi.ts
@@ -325,7 +325,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/appsync/graph-qlapi",
-  version: "2026.04.01.2",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -337,8 +337,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/appsync/manifest.yaml
+++ b/model/aws/appsync/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/appsync"
-version: "2026.04.01.2"
+version: "2026.04.03.1"
 description: "AWS APPSYNC infrastructure models"
 labels:
   - aws

--- a/model/aws/autoscaling/extensions/models/auto_scaling_group.ts
+++ b/model/aws/autoscaling/extensions/models/auto_scaling_group.ts
@@ -695,7 +695,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/autoscaling/auto-scaling-group",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.03.27.1",
@@ -707,8 +707,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/autoscaling/manifest.yaml
+++ b/model/aws/autoscaling/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/autoscaling"
-version: "2026.04.01.1"
+version: "2026.04.03.1"
 description: "AWS AUTOSCALING infrastructure models"
 labels:
   - aws

--- a/model/aws/bedrockagentcore/README.md
+++ b/model/aws/bedrockagentcore/README.md
@@ -14,8 +14,9 @@ methods:
 - **delete** — remove the resource from AWS
 - **sync** — refresh all resource properties from AWS
 
-Use `swamp model type describe @swamp/aws/bedrockagentcore/browser_custom` to
-see the full list of configurable properties and available methods for this
+Use
+`swamp model type describe @swamp/aws/bedrockagentcore/api_key_credential_provider`
+to see the full list of configurable properties and available methods for this
 model.
 
 ## Authentication
@@ -48,17 +49,17 @@ export AWS_SECRET_ACCESS_KEY=wJal...
 ## Usage
 
 ```bash
-# Create a new browser_custom model
-swamp model create @swamp/aws/bedrockagentcore/browser_custom my-browser_custom
+# Create a new api_key_credential_provider model
+swamp model create @swamp/aws/bedrockagentcore/api_key_credential_provider my-api_key_credential_provider
 
 # Edit the model to configure its properties
-swamp model edit my-browser_custom
+swamp model edit my-api_key_credential_provider
 
 # Create the resource in AWS
-swamp model method run my-browser_custom create
+swamp model method run my-api_key_credential_provider create
 
 # Sync current state from AWS
-swamp model method run my-browser_custom sync
+swamp model method run my-api_key_credential_provider sync
 ```
 
 ## License

--- a/model/aws/bedrockagentcore/extensions/models/api_key_credential_provider.ts
+++ b/model/aws/bedrockagentcore/extensions/models/api_key_credential_provider.ts
@@ -1,0 +1,250 @@
+// Auto-generated extension model for @swamp/aws/bedrockagentcore/api-key-credential-provider
+// Do not edit manually. Re-generate with: deno task generate:aws
+
+// deno-lint-ignore-file no-explicit-any
+
+import { z } from "zod";
+import {
+  createResource,
+  deleteResource,
+  isResourceNotFoundError,
+  readResource,
+  updateResource,
+} from "./_lib/aws.ts";
+
+export const TagSchema = z.object({
+  Key: z.string().min(1).max(128).regex(
+    new RegExp("^[a-zA-Z0-9\\s._:/=+@-]*$"),
+  ),
+  Value: z.string().min(0).max(256).regex(
+    new RegExp("^[a-zA-Z0-9\\s._:/=+@-]*$"),
+  ),
+});
+
+const GlobalArgsSchema = z.object({
+  name: z.string().describe(
+    "Instance name for this resource (used as the unique identifier in the factory pattern)",
+  ),
+  Name: z.string().min(1).max(128).regex(new RegExp("^[a-zA-Z0-9\\-_]+$"))
+    .describe("The name of the API key credential provider"),
+  ApiKey: z.string().min(1).max(65536).describe(
+    "The API key to use for authentication",
+  ).optional(),
+  ApiKeySecretArn: z.object({
+    SecretArn: z.string().regex(
+      new RegExp(
+        "^arn:(aws|aws-us-gov):secretsmanager:[A-Za-z0-9-]{1,64}:[0-9]{12}:secret:[a-zA-Z0-9-_/+=.@!]+$",
+      ),
+    ).describe("The ARN of the secret in AWS Secrets Manager"),
+  }).describe("The ARN of the API key secret in AWS Secrets Manager")
+    .optional(),
+  Tags: z.array(TagSchema).describe(
+    "Tags to assign to the API key credential provider",
+  ).optional(),
+});
+
+const StateSchema = z.object({
+  Name: z.string().optional(),
+  ApiKey: z.string().optional(),
+  CredentialProviderArn: z.string(),
+  ApiKeySecretArn: z.object({
+    SecretArn: z.string(),
+  }).optional(),
+  CreatedTime: z.string().optional(),
+  LastUpdatedTime: z.string().optional(),
+  Tags: z.array(TagSchema).optional(),
+}).passthrough();
+
+type StateData = z.infer<typeof StateSchema>;
+
+const InputsSchema = z.object({
+  name: z.string().optional(),
+  Name: z.string().min(1).max(128).regex(new RegExp("^[a-zA-Z0-9\\-_]+$"))
+    .describe("The name of the API key credential provider").optional(),
+  ApiKey: z.string().min(1).max(65536).describe(
+    "The API key to use for authentication",
+  ).optional(),
+  ApiKeySecretArn: z.object({
+    SecretArn: z.string().regex(
+      new RegExp(
+        "^arn:(aws|aws-us-gov):secretsmanager:[A-Za-z0-9-]{1,64}:[0-9]{12}:secret:[a-zA-Z0-9-_/+=.@!]+$",
+      ),
+    ).describe("The ARN of the secret in AWS Secrets Manager").optional(),
+  }).describe("The ARN of the API key secret in AWS Secrets Manager")
+    .optional(),
+  Tags: z.array(TagSchema).describe(
+    "Tags to assign to the API key credential provider",
+  ).optional(),
+});
+
+export const model = {
+  type: "@swamp/aws/bedrockagentcore/api-key-credential-provider",
+  version: "2026.04.03.1",
+  globalArguments: GlobalArgsSchema,
+  inputsSchema: InputsSchema,
+  resources: {
+    state: {
+      description: "BedrockAgentCore ApiKeyCredentialProvider resource state",
+      schema: StateSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    create: {
+      description: "Create a BedrockAgentCore ApiKeyCredentialProvider",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const desiredState: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(g)) {
+          if (key === "name") continue;
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await createResource(
+          "AWS::BedrockAgentCore::ApiKeyCredentialProvider",
+          desiredState,
+        ) as StateData;
+        const instanceName = g.name?.toString() ?? "current";
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    get: {
+      description: "Get a BedrockAgentCore ApiKeyCredentialProvider",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the BedrockAgentCore ApiKeyCredentialProvider",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const result = await readResource(
+          "AWS::BedrockAgentCore::ApiKeyCredentialProvider",
+          args.identifier,
+        ) as StateData;
+        const instanceName = context.globalArgs.name?.toString() ??
+          args.identifier;
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    update: {
+      description: "Update a BedrockAgentCore ApiKeyCredentialProvider",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = g.name?.toString() ?? "current";
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const identifier = existing.CredentialProviderArn?.toString();
+        if (!identifier) {
+          throw new Error("No identifier found in existing state");
+        }
+        const currentState = await readResource(
+          "AWS::BedrockAgentCore::ApiKeyCredentialProvider",
+          identifier,
+        ) as StateData;
+        const desiredState: Record<string, unknown> = { ...currentState };
+        for (const [key, value] of Object.entries(g)) {
+          if (key === "name") continue;
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await updateResource(
+          "AWS::BedrockAgentCore::ApiKeyCredentialProvider",
+          identifier,
+          currentState,
+          desiredState,
+          ["Name"],
+        );
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    delete: {
+      description: "Delete a BedrockAgentCore ApiKeyCredentialProvider",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the BedrockAgentCore ApiKeyCredentialProvider",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const { existed } = await deleteResource(
+          "AWS::BedrockAgentCore::ApiKeyCredentialProvider",
+          args.identifier,
+        );
+        const instanceName = context.globalArgs.name?.toString() ??
+          args.identifier;
+        const handle = await context.writeResource("state", instanceName, {
+          identifier: args.identifier,
+          existed,
+          status: existed ? "deleted" : "not_found",
+          deletedAt: new Date().toISOString(),
+        });
+        return { dataHandles: [handle] };
+      },
+    },
+    sync: {
+      description:
+        "Sync BedrockAgentCore ApiKeyCredentialProvider state from AWS",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = g.name?.toString() ?? "current";
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const identifier = existing.CredentialProviderArn?.toString();
+        if (!identifier) {
+          throw new Error("No identifier found in existing state");
+        }
+        try {
+          const result = await readResource(
+            "AWS::BedrockAgentCore::ApiKeyCredentialProvider",
+            identifier,
+          ) as StateData;
+          const handle = await context.writeResource(
+            "state",
+            instanceName,
+            result,
+          );
+          return { dataHandles: [handle] };
+        } catch (error: unknown) {
+          if (isResourceNotFoundError(error)) {
+            const handle = await context.writeResource("state", instanceName, {
+              identifier,
+              status: "not_found",
+              syncedAt: new Date().toISOString(),
+            });
+            return { dataHandles: [handle] };
+          }
+          throw error;
+        }
+      },
+    },
+  },
+};

--- a/model/aws/bedrockagentcore/extensions/models/browser_custom.ts
+++ b/model/aws/bedrockagentcore/extensions/models/browser_custom.ts
@@ -48,7 +48,9 @@ const GlobalArgsSchema = z.object({
     Enabled: z.boolean().optional(),
   }).describe("Browser signing configuration.").optional(),
   ExecutionRoleArn: z.string().regex(
-    new RegExp("^arn:aws(-[a-z]+)*:iam::[0-9]{12}:role/.+$"),
+    new RegExp(
+      "^arn:(aws(?:-cn|-us-gov|-iso(?:-[bef])?)?):iam::[0-9]{12}:role/.+$",
+    ),
   ).describe(
     "The Amazon Resource Name (ARN) of the IAM role that the browser uses to access resources.",
   ).optional(),
@@ -105,7 +107,9 @@ const InputsSchema = z.object({
     Enabled: z.boolean().optional(),
   }).describe("Browser signing configuration.").optional(),
   ExecutionRoleArn: z.string().regex(
-    new RegExp("^arn:aws(-[a-z]+)*:iam::[0-9]{12}:role/.+$"),
+    new RegExp(
+      "^arn:(aws(?:-cn|-us-gov|-iso(?:-[bef])?)?):iam::[0-9]{12}:role/.+$",
+    ),
   ).describe(
     "The Amazon Resource Name (ARN) of the IAM role that the browser uses to access resources.",
   ).optional(),
@@ -117,10 +121,15 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/bedrockagentcore/browser-custom",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.03.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/bedrockagentcore/extensions/models/code_interpreter_custom.ts
+++ b/model/aws/bedrockagentcore/extensions/models/code_interpreter_custom.ts
@@ -28,7 +28,9 @@ const GlobalArgsSchema = z.object({
   Description: z.string().describe("The description of the code interpreter.")
     .optional(),
   ExecutionRoleArn: z.string().regex(
-    new RegExp("^arn:aws(-[a-z]+)*:iam::[0-9]{12}:role/.+$"),
+    new RegExp(
+      "^arn:(aws(?:-cn|-us-gov|-iso(?:-[bef])?)?):iam::[0-9]{12}:role/.+$",
+    ),
   ).describe(
     "The ARN of the IAM role that the code interpreter uses to access resources.",
   ).optional(),
@@ -70,7 +72,9 @@ const InputsSchema = z.object({
   Description: z.string().describe("The description of the code interpreter.")
     .optional(),
   ExecutionRoleArn: z.string().regex(
-    new RegExp("^arn:aws(-[a-z]+)*:iam::[0-9]{12}:role/.+$"),
+    new RegExp(
+      "^arn:(aws(?:-cn|-us-gov|-iso(?:-[bef])?)?):iam::[0-9]{12}:role/.+$",
+    ),
   ).describe(
     "The ARN of the IAM role that the code interpreter uses to access resources.",
   ).optional(),
@@ -89,10 +93,15 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/bedrockagentcore/code-interpreter-custom",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.03.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/bedrockagentcore/extensions/models/evaluator.ts
+++ b/model/aws/bedrockagentcore/extensions/models/evaluator.ts
@@ -80,6 +80,23 @@ export const LlmAsAJudgeEvaluatorConfigSchema = z.object({
   ),
 });
 
+export const LambdaEvaluatorConfigSchema = z.object({
+  LambdaArn: z.string().regex(
+    new RegExp(
+      "^arn:(aws[a-zA-Z-]*)?:lambda:([a-z]{2}(-gov)?-[a-z]+-\\d{1}):(\\d{12}):function:([a-zA-Z0-9-_.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?$",
+    ),
+  ).describe("The ARN of the Lambda function used for evaluation."),
+  LambdaTimeoutInSeconds: z.number().int().min(1).max(300).describe(
+    "The timeout in seconds for the Lambda function invocation.",
+  ).optional(),
+});
+
+export const CodeBasedEvaluatorConfigSchema = z.object({
+  LambdaConfig: LambdaEvaluatorConfigSchema.describe(
+    "The Lambda function configuration for code-based evaluation.",
+  ),
+});
+
 export const TagSchema = z.object({
   Key: z.string().min(1).max(128),
   Value: z.string().min(0).max(256),
@@ -97,7 +114,10 @@ const GlobalArgsSchema = z.object({
   EvaluatorConfig: z.object({
     LlmAsAJudge: LlmAsAJudgeEvaluatorConfigSchema.describe(
       "The configuration for LLM-as-a-Judge evaluation.",
-    ),
+    ).optional(),
+    CodeBased: CodeBasedEvaluatorConfigSchema.describe(
+      "The configuration for code-based evaluation using a Lambda function.",
+    ).optional(),
   }).describe("The configuration for the evaluator."),
   Level: z.enum(["TOOL_CALL", "TRACE", "SESSION"]).describe(
     "The evaluation level that determines the scope of evaluation.",
@@ -114,6 +134,7 @@ const StateSchema = z.object({
   Description: z.string().optional(),
   EvaluatorConfig: z.object({
     LlmAsAJudge: LlmAsAJudgeEvaluatorConfigSchema,
+    CodeBased: CodeBasedEvaluatorConfigSchema,
   }).optional(),
   Level: z.string().optional(),
   Status: z.string().optional(),
@@ -136,6 +157,9 @@ const InputsSchema = z.object({
     LlmAsAJudge: LlmAsAJudgeEvaluatorConfigSchema.describe(
       "The configuration for LLM-as-a-Judge evaluation.",
     ).optional(),
+    CodeBased: CodeBasedEvaluatorConfigSchema.describe(
+      "The configuration for code-based evaluation using a Lambda function.",
+    ).optional(),
   }).describe("The configuration for the evaluator.").optional(),
   Level: z.enum(["TOOL_CALL", "TRACE", "SESSION"]).describe(
     "The evaluation level that determines the scope of evaluation.",
@@ -147,10 +171,15 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/bedrockagentcore/evaluator",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.03.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/bedrockagentcore/extensions/models/gateway.ts
+++ b/model/aws/bedrockagentcore/extensions/models/gateway.ts
@@ -209,7 +209,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/bedrockagentcore/gateway",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -221,8 +221,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/bedrockagentcore/extensions/models/memory.ts
+++ b/model/aws/bedrockagentcore/extensions/models/memory.ts
@@ -25,6 +25,13 @@ export const SemanticMemoryStrategySchema = z.object({
       ),
     ),
   ).describe("List of namespaces for memory strategy").optional(),
+  NamespaceTemplates: z.array(
+    z.string().regex(
+      new RegExp(
+        "^[a-zA-Z0-9\\-_/]*(\\{(actorId|sessionId|memoryStrategyId)\\}[a-zA-Z0-9\\-_/]*)*$",
+      ),
+    ),
+  ).describe("List of namespaces for memory strategy").optional(),
   StrategyId: z.string().min(12).regex(
     new RegExp("^[a-zA-Z][a-zA-Z0-9-_]{0,99}-[a-zA-Z0-9]{10}$"),
   ).describe("Unique identifier for the memory strategy").optional(),
@@ -57,6 +64,13 @@ export const SummaryMemoryStrategySchema = z.object({
       ),
     ),
   ).describe("List of namespaces for memory strategy").optional(),
+  NamespaceTemplates: z.array(
+    z.string().regex(
+      new RegExp(
+        "^[a-zA-Z0-9\\-_/]*(\\{(actorId|sessionId|memoryStrategyId)\\}[a-zA-Z0-9\\-_/]*)*$",
+      ),
+    ),
+  ).describe("List of namespaces for memory strategy").optional(),
   StrategyId: z.string().min(12).regex(
     new RegExp("^[a-zA-Z][a-zA-Z0-9-_]{0,99}-[a-zA-Z0-9]{10}$"),
   ).describe("Unique identifier for the memory strategy").optional(),
@@ -83,6 +97,13 @@ export const UserPreferenceMemoryStrategySchema = z.object({
   Description: z.string().describe("Description of the Memory resource")
     .optional(),
   Namespaces: z.array(
+    z.string().regex(
+      new RegExp(
+        "^[a-zA-Z0-9\\-_/]*(\\{(actorId|sessionId|memoryStrategyId)\\}[a-zA-Z0-9\\-_/]*)*$",
+      ),
+    ),
+  ).describe("List of namespaces for memory strategy").optional(),
+  NamespaceTemplates: z.array(
     z.string().regex(
       new RegExp(
         "^[a-zA-Z0-9\\-_/]*(\\{(actorId|sessionId|memoryStrategyId)\\}[a-zA-Z0-9\\-_/]*)*$",
@@ -184,7 +205,7 @@ export const TriggerConditionInputSchema = z.object({
 export const InvocationConfigurationInputSchema = z.object({
   TopicArn: z.string().regex(
     new RegExp(
-      "^arn:aws:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$",
+      "^arn:(aws(?:-cn|-us-gov|-iso(?:-[bef])?)?):[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$",
     ),
   ).describe("ARN format").optional(),
   PayloadDeliveryBucketName: z.string().regex(
@@ -224,6 +245,13 @@ export const EpisodicOverrideReflectionConfigurationInputSchema = z.object({
       ),
     ),
   ).describe("List of namespaces for memory strategy").optional(),
+  NamespaceTemplates: z.array(
+    z.string().regex(
+      new RegExp(
+        "^[a-zA-Z0-9\\-_/]*(\\{(actorId|sessionId|memoryStrategyId)\\}[a-zA-Z0-9\\-_/]*)*$",
+      ),
+    ),
+  ).describe("List of namespaces for memory strategy").optional(),
 });
 
 export const EpisodicOverrideSchema = z.object({
@@ -248,6 +276,13 @@ export const CustomMemoryStrategySchema = z.object({
   Description: z.string().describe("Description of the Memory resource")
     .optional(),
   Namespaces: z.array(
+    z.string().regex(
+      new RegExp(
+        "^[a-zA-Z0-9\\-_/]*(\\{(actorId|sessionId|memoryStrategyId)\\}[a-zA-Z0-9\\-_/]*)*$",
+      ),
+    ),
+  ).describe("List of namespaces for memory strategy").optional(),
+  NamespaceTemplates: z.array(
     z.string().regex(
       new RegExp(
         "^[a-zA-Z0-9\\-_/]*(\\{(actorId|sessionId|memoryStrategyId)\\}[a-zA-Z0-9\\-_/]*)*$",
@@ -281,7 +316,14 @@ export const EpisodicReflectionConfigurationInputSchema = z.object({
         "^[a-zA-Z0-9\\-_/]*(\\{(actorId|sessionId|memoryStrategyId)\\}[a-zA-Z0-9\\-_/]*)*$",
       ),
     ),
-  ).describe("List of namespaces for memory strategy"),
+  ).describe("List of namespaces for memory strategy").optional(),
+  NamespaceTemplates: z.array(
+    z.string().regex(
+      new RegExp(
+        "^[a-zA-Z0-9\\-_/]*(\\{(actorId|sessionId|memoryStrategyId)\\}[a-zA-Z0-9\\-_/]*)*$",
+      ),
+    ),
+  ).describe("List of namespaces for memory strategy").optional(),
 });
 
 export const EpisodicMemoryStrategySchema = z.object({
@@ -291,6 +333,13 @@ export const EpisodicMemoryStrategySchema = z.object({
   Description: z.string().describe("Description of the Memory resource")
     .optional(),
   Namespaces: z.array(
+    z.string().regex(
+      new RegExp(
+        "^[a-zA-Z0-9\\-_/]*(\\{(actorId|sessionId|memoryStrategyId)\\}[a-zA-Z0-9\\-_/]*)*$",
+      ),
+    ),
+  ).describe("List of namespaces for memory strategy").optional(),
+  NamespaceTemplates: z.array(
     z.string().regex(
       new RegExp(
         "^[a-zA-Z0-9\\-_/]*(\\{(actorId|sessionId|memoryStrategyId)\\}[a-zA-Z0-9\\-_/]*)*$",
@@ -336,7 +385,7 @@ export const ContentConfigurationSchema = z.object({
 export const KinesisResourceSchema = z.object({
   DataStreamArn: z.string().regex(
     new RegExp(
-      "^arn:aws:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$",
+      "^arn:(aws(?:-cn|-us-gov|-iso(?:-[bef])?)?):[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$",
     ),
   ).describe("ARN format"),
   ContentConfigurations: z.array(ContentConfigurationSchema),
@@ -357,12 +406,12 @@ const GlobalArgsSchema = z.object({
     .optional(),
   EncryptionKeyArn: z.string().regex(
     new RegExp(
-      "^arn:aws:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$",
+      "^arn:(aws(?:-cn|-us-gov|-iso(?:-[bef])?)?):[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$",
     ),
   ).describe("ARN format").optional(),
   MemoryExecutionRoleArn: z.string().regex(
     new RegExp(
-      "^arn:aws:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$",
+      "^arn:(aws(?:-cn|-us-gov|-iso(?:-[bef])?)?):[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$",
     ),
   ).describe("ARN format").optional(),
   EventExpiryDuration: z.number().int().min(3).max(365).describe(
@@ -410,12 +459,12 @@ const InputsSchema = z.object({
     .optional(),
   EncryptionKeyArn: z.string().regex(
     new RegExp(
-      "^arn:aws:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$",
+      "^arn:(aws(?:-cn|-us-gov|-iso(?:-[bef])?)?):[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$",
     ),
   ).describe("ARN format").optional(),
   MemoryExecutionRoleArn: z.string().regex(
     new RegExp(
-      "^arn:aws:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$",
+      "^arn:(aws(?:-cn|-us-gov|-iso(?:-[bef])?)?):[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}$",
     ),
   ).describe("ARN format").optional(),
   EventExpiryDuration: z.number().int().min(3).max(365).describe(
@@ -435,10 +484,15 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/bedrockagentcore/memory",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.03.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/bedrockagentcore/extensions/models/online_evaluation_config.ts
+++ b/model/aws/bedrockagentcore/extensions/models/online_evaluation_config.ts
@@ -224,7 +224,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/bedrockagentcore/online-evaluation-config",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.03.27.1",
@@ -236,8 +236,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/bedrockagentcore/extensions/models/runtime.ts
+++ b/model/aws/bedrockagentcore/extensions/models/runtime.ts
@@ -34,8 +34,13 @@ export const CodeSchema = z.object({
 
 export const CodeConfigurationSchema = z.object({
   Code: CodeSchema.describe("Object represents source code from zip file"),
-  Runtime: z.enum(["PYTHON_3_10", "PYTHON_3_11", "PYTHON_3_12", "PYTHON_3_13"])
-    .describe("Managed runtime types"),
+  Runtime: z.enum([
+    "PYTHON_3_10",
+    "PYTHON_3_11",
+    "PYTHON_3_12",
+    "PYTHON_3_13",
+    "PYTHON_3_14",
+  ]).describe("Managed runtime types"),
   EntryPoint: z.array(z.string()).describe("List of entry points"),
 });
 
@@ -117,7 +122,7 @@ const GlobalArgsSchema = z.object({
       "Network mode configuration for VPC",
     ).optional(),
   }).describe("Network access configuration for the Agent"),
-  ProtocolConfiguration: z.enum(["MCP", "HTTP", "A2A"]).describe(
+  ProtocolConfiguration: z.enum(["MCP", "HTTP", "A2A", "AGUI"]).describe(
     "Protocol configuration for the agent runtime",
   ).optional(),
   EnvironmentVariables: z.record(z.string(), z.string().max(2048)).describe(
@@ -221,7 +226,7 @@ const InputsSchema = z.object({
       "Network mode configuration for VPC",
     ).optional(),
   }).describe("Network access configuration for the Agent").optional(),
-  ProtocolConfiguration: z.enum(["MCP", "HTTP", "A2A"]).describe(
+  ProtocolConfiguration: z.enum(["MCP", "HTTP", "A2A", "AGUI"]).describe(
     "Protocol configuration for the agent runtime",
   ).optional(),
   EnvironmentVariables: z.record(z.string(), z.string().max(2048)).describe(
@@ -264,10 +269,15 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/bedrockagentcore/runtime",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.03.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/bedrockagentcore/manifest.yaml
+++ b/model/aws/bedrockagentcore/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/bedrockagentcore"
-version: "2026.04.01.1"
+version: "2026.04.03.1"
 description: "AWS BEDROCKAGENTCORE infrastructure models"
 labels:
   - aws
@@ -9,8 +9,10 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: gateway
+  - Added: api_key_credential_provider
+  - Updated: browser_custom, code_interpreter_custom, evaluator, gateway, memory, online_evaluation_config, runtime
 models:
+  - api_key_credential_provider.ts
   - browser_custom.ts
   - browser_profile.ts
   - code_interpreter_custom.ts

--- a/model/aws/customerprofiles/extensions/models/segment_definition.ts
+++ b/model/aws/customerprofiles/extensions/models/segment_definition.ts
@@ -236,6 +236,21 @@ export const TagSchema = z.object({
   ),
 });
 
+export const SortAttributeSchema = z.object({
+  Name: z.string().min(1).max(255).describe(
+    "The name of the attribute to sort by.",
+  ),
+  Order: z.enum(["ASC", "DESC"]).describe(
+    "The sort order for the attribute (ascending or descending).",
+  ),
+  DataType: z.enum(["STRING", "NUMBER", "DATE"]).describe(
+    "The data type of the sort attribute (e.g., string, number, date).",
+  ).optional(),
+  Type: z.enum(["PROFILE", "CALCULATED"]).describe(
+    "The type of attribute (e.g., profile, calculated).",
+  ).optional(),
+});
+
 const GlobalArgsSchema = z.object({
   name: z.string().describe(
     "Instance name for this resource (used as the unique identifier in the factory pattern)",
@@ -265,6 +280,12 @@ const GlobalArgsSchema = z.object({
   Tags: z.array(TagSchema).describe(
     "The tags used to organize, track, or control access for this resource.",
   ).optional(),
+  SegmentSort: z.object({
+    Attributes: z.array(SortAttributeSchema).describe(
+      "A list of attributes used to sort the segments and their ordering preferences.",
+    ),
+  }).describe("The segment sort configuration for ordering segment results.")
+    .optional(),
 });
 
 const StateSchema = z.object({
@@ -281,6 +302,9 @@ const StateSchema = z.object({
   SegmentDefinitionArn: z.string().optional(),
   SegmentType: z.string().optional(),
   Tags: z.array(TagSchema).optional(),
+  SegmentSort: z.object({
+    Attributes: z.array(SortAttributeSchema),
+  }).optional(),
 }).passthrough();
 
 type StateData = z.infer<typeof StateSchema>;
@@ -312,15 +336,26 @@ const InputsSchema = z.object({
   Tags: z.array(TagSchema).describe(
     "The tags used to organize, track, or control access for this resource.",
   ).optional(),
+  SegmentSort: z.object({
+    Attributes: z.array(SortAttributeSchema).describe(
+      "A list of attributes used to sort the segments and their ordering preferences.",
+    ).optional(),
+  }).describe("The segment sort configuration for ordering segment results.")
+    .optional(),
 });
 
 export const model = {
   type: "@swamp/aws/customerprofiles/segment-definition",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
       description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.03.1",
+      description: "Added: SegmentSort",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
   ],

--- a/model/aws/customerprofiles/manifest.yaml
+++ b/model/aws/customerprofiles/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/customerprofiles"
-version: "2026.04.01.1"
+version: "2026.04.03.1"
 description: "AWS CUSTOMERPROFILES infrastructure models"
 labels:
   - aws
@@ -9,7 +9,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Added: recommender
+  - Updated: segment_definition
 models:
   - calculated_attribute_definition.ts
   - domain.ts

--- a/model/aws/datazone/extensions/models/connection.ts
+++ b/model/aws/datazone/extensions/models/connection.ts
@@ -469,7 +469,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/datazone/connection",
-  version: "2026.04.01.2",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -481,8 +481,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/datazone/extensions/models/project.ts
+++ b/model/aws/datazone/extensions/models/project.ts
@@ -120,7 +120,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/datazone/project",
-  version: "2026.04.01.2",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -132,8 +132,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/datazone/extensions/models/project_profile.ts
+++ b/model/aws/datazone/extensions/models/project_profile.ts
@@ -117,7 +117,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/datazone/project-profile",
-  version: "2026.04.01.2",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -130,8 +130,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/datazone/manifest.yaml
+++ b/model/aws/datazone/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/datazone"
-version: "2026.04.01.2"
+version: "2026.04.03.1"
 description: "AWS DATAZONE infrastructure models"
 labels:
   - aws

--- a/model/aws/deadline/extensions/models/fleet.ts
+++ b/model/aws/deadline/extensions/models/fleet.ts
@@ -35,6 +35,12 @@ export const FleetAttributeCapabilitySchema = z.object({
   ),
 });
 
+export const CustomerManagedAutoScalingConfigurationSchema = z.object({
+  StandbyWorkerCount: z.number().int().min(0).max(2147483647).optional(),
+  WorkerIdleDurationSeconds: z.number().int().min(0).max(2147483647).optional(),
+  ScaleOutWorkersPerMinute: z.number().int().min(1).max(2147483647).optional(),
+});
+
 export const VCpuCountRangeSchema = z.object({
   Min: z.number().int().min(1).max(10000),
   Max: z.number().int().min(1).max(10000).optional(),
@@ -69,6 +75,8 @@ export const CustomerManagedWorkerCapabilitiesSchema = z.object({
 
 export const CustomerManagedFleetConfigurationSchema = z.object({
   Mode: z.enum(["NO_SCALING", "EVENT_BASED_AUTO_SCALING"]),
+  AutoScalingConfiguration: CustomerManagedAutoScalingConfigurationSchema
+    .optional(),
   WorkerCapabilities: CustomerManagedWorkerCapabilitiesSchema,
   StorageProfileId: z.string().regex(new RegExp("^sp-[0-9a-f]{32}$"))
     .optional(),
@@ -115,11 +123,19 @@ export const VpcConfigurationSchema = z.object({
   ResourceConfigurationArns: z.array(z.string().min(1).max(2048)).optional(),
 });
 
+export const ServiceManagedEc2AutoScalingConfigurationSchema = z.object({
+  StandbyWorkerCount: z.number().int().min(0).max(2147483647).optional(),
+  WorkerIdleDurationSeconds: z.number().int().min(0).max(86400).optional(),
+  ScaleOutWorkersPerMinute: z.number().int().min(1).max(2147483647).optional(),
+});
+
 export const ServiceManagedEc2FleetConfigurationSchema = z.object({
   InstanceCapabilities: ServiceManagedEc2InstanceCapabilitiesSchema,
   InstanceMarketOptions: ServiceManagedEc2InstanceMarketOptionsSchema,
   VpcConfiguration: VpcConfigurationSchema.optional(),
   StorageProfileId: z.string().regex(new RegExp("^sp-[0-9a-f]{32}$"))
+    .optional(),
+  AutoScalingConfiguration: ServiceManagedEc2AutoScalingConfigurationSchema
     .optional(),
 });
 
@@ -223,10 +239,15 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/deadline/fleet",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.03.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/deadline/manifest.yaml
+++ b/model/aws/deadline/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/deadline"
-version: "2026.04.01.1"
+version: "2026.04.03.1"
 description: "AWS DEADLINE infrastructure models"
 labels:
   - aws
@@ -9,7 +9,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: farm, fleet, license_endpoint, limit, metered_product, monitor, queue, queue_environment, queue_fleet_association, queue_limit_association, storage_profile
+  - Updated: fleet
 models:
   - farm.ts
   - fleet.ts

--- a/model/aws/devopsagent/extensions/models/agent_space.ts
+++ b/model/aws/devopsagent/extensions/models/agent_space.ts
@@ -84,7 +84,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/devopsagent/agent-space",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.03.27.1",
@@ -96,8 +96,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/devopsagent/extensions/models/service.ts
+++ b/model/aws/devopsagent/extensions/models/service.ts
@@ -76,7 +76,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/devopsagent/service",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.03.27.1",
@@ -88,8 +88,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/devopsagent/manifest.yaml
+++ b/model/aws/devopsagent/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/devopsagent"
-version: "2026.04.01.1"
+version: "2026.04.03.1"
 description: "AWS DEVOPSAGENT infrastructure models"
 labels:
   - aws

--- a/model/aws/ecs/extensions/models/capacity_provider.ts
+++ b/model/aws/ecs/extensions/models/capacity_provider.ts
@@ -232,7 +232,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/ecs/capacity-provider",
-  version: "2026.04.01.2",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -244,8 +244,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/ecs/extensions/models/daemon.ts
+++ b/model/aws/ecs/extensions/models/daemon.ts
@@ -1,0 +1,253 @@
+// Auto-generated extension model for @swamp/aws/ecs/daemon
+// Do not edit manually. Re-generate with: deno task generate:aws
+
+// deno-lint-ignore-file no-explicit-any
+
+import { z } from "zod";
+import {
+  createResource,
+  deleteResource,
+  isResourceNotFoundError,
+  readResource,
+  updateResource,
+} from "./_lib/aws.ts";
+
+export const DaemonAlarmConfigurationSchema = z.object({
+  AlarmNames: z.array(z.string()).optional(),
+  Enable: z.boolean().optional(),
+});
+
+export const TagSchema = z.object({
+  Value: z.string().optional(),
+  Key: z.string(),
+});
+
+const GlobalArgsSchema = z.object({
+  name: z.string().describe(
+    "Instance name for this resource (used as the unique identifier in the factory pattern)",
+  ),
+  ClusterArn: z.string().optional(),
+  DaemonTaskDefinitionArn: z.string().optional(),
+  DaemonName: z.string().optional(),
+  EnableECSManagedTags: z.boolean().optional(),
+  EnableExecuteCommand: z.boolean().optional(),
+  PropagateTags: z.enum(["DAEMON", "NONE"]).optional(),
+  CapacityProviderArns: z.array(z.string()).optional(),
+  DeploymentConfiguration: z.object({
+    DrainPercent: z.number().min(0).max(100).optional(),
+    BakeTimeInMinutes: z.number().int().min(0).max(1440).optional(),
+    Alarms: DaemonAlarmConfigurationSchema.optional(),
+  }).optional(),
+  Tags: z.array(TagSchema).optional(),
+});
+
+const StateSchema = z.object({
+  ClusterArn: z.string().optional(),
+  DaemonStatus: z.string().optional(),
+  DaemonTaskDefinitionArn: z.string().optional(),
+  DaemonName: z.string().optional(),
+  EnableECSManagedTags: z.boolean().optional(),
+  EnableExecuteCommand: z.boolean().optional(),
+  PropagateTags: z.string().optional(),
+  CreatedAt: z.string().optional(),
+  UpdatedAt: z.string().optional(),
+  DeploymentArn: z.string().optional(),
+  CapacityProviderArns: z.array(z.string()).optional(),
+  DaemonArn: z.string(),
+  DeploymentConfiguration: z.object({
+    DrainPercent: z.number(),
+    BakeTimeInMinutes: z.number(),
+    Alarms: DaemonAlarmConfigurationSchema,
+  }).optional(),
+  Tags: z.array(TagSchema).optional(),
+}).passthrough();
+
+type StateData = z.infer<typeof StateSchema>;
+
+const InputsSchema = z.object({
+  name: z.string().optional(),
+  ClusterArn: z.string().optional(),
+  DaemonTaskDefinitionArn: z.string().optional(),
+  DaemonName: z.string().optional(),
+  EnableECSManagedTags: z.boolean().optional(),
+  EnableExecuteCommand: z.boolean().optional(),
+  PropagateTags: z.enum(["DAEMON", "NONE"]).optional(),
+  CapacityProviderArns: z.array(z.string()).optional(),
+  DeploymentConfiguration: z.object({
+    DrainPercent: z.number().min(0).max(100).optional(),
+    BakeTimeInMinutes: z.number().int().min(0).max(1440).optional(),
+    Alarms: DaemonAlarmConfigurationSchema.optional(),
+  }).optional(),
+  Tags: z.array(TagSchema).optional(),
+});
+
+export const model = {
+  type: "@swamp/aws/ecs/daemon",
+  version: "2026.04.03.1",
+  globalArguments: GlobalArgsSchema,
+  inputsSchema: InputsSchema,
+  resources: {
+    state: {
+      description: "ECS Daemon resource state",
+      schema: StateSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    create: {
+      description: "Create a ECS Daemon",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const desiredState: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(g)) {
+          if (key === "name") continue;
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await createResource(
+          "AWS::ECS::Daemon",
+          desiredState,
+        ) as StateData;
+        const instanceName = g.name?.toString() ?? "current";
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    get: {
+      description: "Get a ECS Daemon",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the ECS Daemon",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const result = await readResource(
+          "AWS::ECS::Daemon",
+          args.identifier,
+        ) as StateData;
+        const instanceName = context.globalArgs.name?.toString() ??
+          args.identifier;
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    update: {
+      description: "Update a ECS Daemon",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = g.name?.toString() ?? "current";
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const identifier = existing.DaemonArn?.toString();
+        if (!identifier) {
+          throw new Error("No identifier found in existing state");
+        }
+        const currentState = await readResource(
+          "AWS::ECS::Daemon",
+          identifier,
+        ) as StateData;
+        const desiredState: Record<string, unknown> = { ...currentState };
+        for (const [key, value] of Object.entries(g)) {
+          if (key === "name") continue;
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await updateResource(
+          "AWS::ECS::Daemon",
+          identifier,
+          currentState,
+          desiredState,
+          ["DaemonName", "ClusterArn"],
+        );
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    delete: {
+      description: "Delete a ECS Daemon",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the ECS Daemon",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const { existed } = await deleteResource(
+          "AWS::ECS::Daemon",
+          args.identifier,
+        );
+        const instanceName = context.globalArgs.name?.toString() ??
+          args.identifier;
+        const handle = await context.writeResource("state", instanceName, {
+          identifier: args.identifier,
+          existed,
+          status: existed ? "deleted" : "not_found",
+          deletedAt: new Date().toISOString(),
+        });
+        return { dataHandles: [handle] };
+      },
+    },
+    sync: {
+      description: "Sync ECS Daemon state from AWS",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = g.name?.toString() ?? "current";
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const identifier = existing.DaemonArn?.toString();
+        if (!identifier) {
+          throw new Error("No identifier found in existing state");
+        }
+        try {
+          const result = await readResource(
+            "AWS::ECS::Daemon",
+            identifier,
+          ) as StateData;
+          const handle = await context.writeResource(
+            "state",
+            instanceName,
+            result,
+          );
+          return { dataHandles: [handle] };
+        } catch (error: unknown) {
+          if (isResourceNotFoundError(error)) {
+            const handle = await context.writeResource("state", instanceName, {
+              identifier,
+              status: "not_found",
+              syncedAt: new Date().toISOString(),
+            });
+            return { dataHandles: [handle] };
+          }
+          throw error;
+        }
+      },
+    },
+  },
+};

--- a/model/aws/ecs/extensions/models/daemon_task_definition.ts
+++ b/model/aws/ecs/extensions/models/daemon_task_definition.ts
@@ -1,0 +1,368 @@
+// Auto-generated extension model for @swamp/aws/ecs/daemon-task-definition
+// Do not edit manually. Re-generate with: deno task generate:aws
+
+// deno-lint-ignore-file no-explicit-any
+
+import { z } from "zod";
+import {
+  createResource,
+  deleteResource,
+  isResourceNotFoundError,
+  readResource,
+  updateResource,
+} from "./_lib/aws.ts";
+
+export const HostVolumePropertiesSchema = z.object({
+  SourcePath: z.string().optional(),
+});
+
+export const VolumeSchema = z.object({
+  Host: HostVolumePropertiesSchema.optional(),
+  Name: z.string().optional(),
+});
+
+export const SecretSchema = z.object({
+  ValueFrom: z.string(),
+  Name: z.string(),
+});
+
+export const HealthCheckSchema = z.object({
+  Command: z.array(z.string()).optional(),
+  Timeout: z.number().int().optional(),
+  Retries: z.number().int().optional(),
+  Interval: z.number().int().optional(),
+  StartPeriod: z.number().int().optional(),
+});
+
+export const LogConfigurationSchema = z.object({
+  SecretOptions: z.array(SecretSchema).optional(),
+  Options: z.record(z.string(), z.string()).optional(),
+  LogDriver: z.string(),
+});
+
+export const EnvironmentFileSchema = z.object({
+  Type: z.string().optional(),
+  Value: z.string().optional(),
+});
+
+export const FirelensConfigurationSchema = z.object({
+  Options: z.record(z.string(), z.string()).optional(),
+  Type: z.string().optional(),
+});
+
+export const SystemControlSchema = z.object({
+  Value: z.string().optional(),
+  Namespace: z.string().optional(),
+});
+
+export const UlimitSchema = z.object({
+  SoftLimit: z.number().int(),
+  HardLimit: z.number().int(),
+  Name: z.string(),
+});
+
+export const RepositoryCredentialsSchema = z.object({
+  CredentialsParameter: z.string().optional(),
+});
+
+export const KernelCapabilitiesSchema = z.object({
+  Add: z.array(z.string()).optional(),
+  Drop: z.array(z.string()).optional(),
+});
+
+export const TmpfsSchema = z.object({
+  Size: z.number().int(),
+  ContainerPath: z.string().optional(),
+  MountOptions: z.array(z.string()).optional(),
+});
+
+export const DeviceSchema = z.object({
+  HostPath: z.string().optional(),
+  Permissions: z.array(z.string()).optional(),
+  ContainerPath: z.string().optional(),
+});
+
+export const LinuxParametersSchema = z.object({
+  Capabilities: KernelCapabilitiesSchema.optional(),
+  Tmpfs: z.array(TmpfsSchema).optional(),
+  Devices: z.array(DeviceSchema).optional(),
+  InitProcessEnabled: z.boolean().optional(),
+});
+
+export const RestartPolicySchema = z.object({
+  IgnoredExitCodes: z.array(z.number().int()).optional(),
+  RestartAttemptPeriod: z.number().int().optional(),
+  Enabled: z.boolean().optional(),
+});
+
+export const MountPointSchema = z.object({
+  ReadOnly: z.boolean().optional(),
+  SourceVolume: z.string().optional(),
+  ContainerPath: z.string().optional(),
+});
+
+export const ContainerDependencySchema = z.object({
+  Condition: z.string().optional(),
+  ContainerName: z.string().optional(),
+});
+
+export const KeyValuePairSchema = z.object({
+  Value: z.string().optional(),
+  Name: z.string().optional(),
+});
+
+export const DaemonContainerDefinitionSchema = z.object({
+  User: z.string().optional(),
+  Secrets: z.array(SecretSchema).optional(),
+  Memory: z.number().int().optional(),
+  Privileged: z.boolean().optional(),
+  StartTimeout: z.number().int().optional(),
+  HealthCheck: HealthCheckSchema.optional(),
+  Cpu: z.number().int().optional(),
+  EntryPoint: z.array(z.string()).optional(),
+  ReadonlyRootFilesystem: z.boolean().optional(),
+  Image: z.string(),
+  Essential: z.boolean().optional(),
+  LogConfiguration: LogConfigurationSchema.optional(),
+  EnvironmentFiles: z.array(EnvironmentFileSchema).optional(),
+  Name: z.string(),
+  FirelensConfiguration: FirelensConfigurationSchema.optional(),
+  SystemControls: z.array(SystemControlSchema).optional(),
+  Interactive: z.boolean().optional(),
+  Ulimits: z.array(UlimitSchema).optional(),
+  StopTimeout: z.number().int().optional(),
+  WorkingDirectory: z.string().optional(),
+  MemoryReservation: z.number().int().optional(),
+  RepositoryCredentials: RepositoryCredentialsSchema.optional(),
+  LinuxParameters: LinuxParametersSchema.optional(),
+  RestartPolicy: RestartPolicySchema.optional(),
+  PseudoTerminal: z.boolean().optional(),
+  MountPoints: z.array(MountPointSchema).optional(),
+  DependsOn: z.array(ContainerDependencySchema).optional(),
+  Command: z.array(z.string()).optional(),
+  Environment: z.array(KeyValuePairSchema).optional(),
+});
+
+export const TagSchema = z.object({
+  Value: z.string().optional(),
+  Key: z.string().optional(),
+});
+
+const GlobalArgsSchema = z.object({
+  name: z.string().describe(
+    "Instance name for this resource (used as the unique identifier in the factory pattern)",
+  ),
+  ExecutionRoleArn: z.string().optional(),
+  TaskRoleArn: z.string().optional(),
+  Volumes: z.array(VolumeSchema).optional(),
+  Memory: z.string().optional(),
+  ContainerDefinitions: z.array(DaemonContainerDefinitionSchema).optional(),
+  Family: z.string().optional(),
+  Cpu: z.string().optional(),
+  Tags: z.array(TagSchema).optional(),
+});
+
+const StateSchema = z.object({
+  ExecutionRoleArn: z.string().optional(),
+  TaskRoleArn: z.string().optional(),
+  DaemonTaskDefinitionArn: z.string(),
+  Volumes: z.array(VolumeSchema).optional(),
+  Memory: z.string().optional(),
+  ContainerDefinitions: z.array(DaemonContainerDefinitionSchema).optional(),
+  Family: z.string().optional(),
+  Cpu: z.string().optional(),
+  Tags: z.array(TagSchema).optional(),
+}).passthrough();
+
+type StateData = z.infer<typeof StateSchema>;
+
+const InputsSchema = z.object({
+  name: z.string().optional(),
+  ExecutionRoleArn: z.string().optional(),
+  TaskRoleArn: z.string().optional(),
+  Volumes: z.array(VolumeSchema).optional(),
+  Memory: z.string().optional(),
+  ContainerDefinitions: z.array(DaemonContainerDefinitionSchema).optional(),
+  Family: z.string().optional(),
+  Cpu: z.string().optional(),
+  Tags: z.array(TagSchema).optional(),
+});
+
+export const model = {
+  type: "@swamp/aws/ecs/daemon-task-definition",
+  version: "2026.04.03.1",
+  globalArguments: GlobalArgsSchema,
+  inputsSchema: InputsSchema,
+  resources: {
+    state: {
+      description: "ECS DaemonTaskDefinition resource state",
+      schema: StateSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    create: {
+      description: "Create a ECS DaemonTaskDefinition",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const desiredState: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(g)) {
+          if (key === "name") continue;
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await createResource(
+          "AWS::ECS::DaemonTaskDefinition",
+          desiredState,
+        ) as StateData;
+        const instanceName = g.name?.toString() ?? "current";
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    get: {
+      description: "Get a ECS DaemonTaskDefinition",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the ECS DaemonTaskDefinition",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const result = await readResource(
+          "AWS::ECS::DaemonTaskDefinition",
+          args.identifier,
+        ) as StateData;
+        const instanceName = context.globalArgs.name?.toString() ??
+          args.identifier;
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    update: {
+      description: "Update a ECS DaemonTaskDefinition",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = g.name?.toString() ?? "current";
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const identifier = existing.DaemonTaskDefinitionArn?.toString();
+        if (!identifier) {
+          throw new Error("No identifier found in existing state");
+        }
+        const currentState = await readResource(
+          "AWS::ECS::DaemonTaskDefinition",
+          identifier,
+        ) as StateData;
+        const desiredState: Record<string, unknown> = { ...currentState };
+        for (const [key, value] of Object.entries(g)) {
+          if (key === "name") continue;
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await updateResource(
+          "AWS::ECS::DaemonTaskDefinition",
+          identifier,
+          currentState,
+          desiredState,
+          [
+            "Family",
+            "ContainerDefinitions",
+            "Cpu",
+            "Memory",
+            "ExecutionRoleArn",
+            "TaskRoleArn",
+            "Volumes",
+          ],
+        );
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    delete: {
+      description: "Delete a ECS DaemonTaskDefinition",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the ECS DaemonTaskDefinition",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const { existed } = await deleteResource(
+          "AWS::ECS::DaemonTaskDefinition",
+          args.identifier,
+        );
+        const instanceName = context.globalArgs.name?.toString() ??
+          args.identifier;
+        const handle = await context.writeResource("state", instanceName, {
+          identifier: args.identifier,
+          existed,
+          status: existed ? "deleted" : "not_found",
+          deletedAt: new Date().toISOString(),
+        });
+        return { dataHandles: [handle] };
+      },
+    },
+    sync: {
+      description: "Sync ECS DaemonTaskDefinition state from AWS",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = g.name?.toString() ?? "current";
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const identifier = existing.DaemonTaskDefinitionArn?.toString();
+        if (!identifier) {
+          throw new Error("No identifier found in existing state");
+        }
+        try {
+          const result = await readResource(
+            "AWS::ECS::DaemonTaskDefinition",
+            identifier,
+          ) as StateData;
+          const handle = await context.writeResource(
+            "state",
+            instanceName,
+            result,
+          );
+          return { dataHandles: [handle] };
+        } catch (error: unknown) {
+          if (isResourceNotFoundError(error)) {
+            const handle = await context.writeResource("state", instanceName, {
+              identifier,
+              status: "not_found",
+              syncedAt: new Date().toISOString(),
+            });
+            return { dataHandles: [handle] };
+          }
+          throw error;
+        }
+      },
+    },
+  },
+};

--- a/model/aws/ecs/manifest.yaml
+++ b/model/aws/ecs/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/ecs"
-version: "2026.04.01.2"
+version: "2026.04.03.1"
 description: "AWS ECS infrastructure models"
 labels:
   - aws
@@ -9,11 +9,14 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
+  - Added: daemon, daemon_task_definition
   - Updated: capacity_provider
 models:
   - capacity_provider.ts
   - cluster.ts
   - cluster_capacity_provider_associations.ts
+  - daemon.ts
+  - daemon_task_definition.ts
   - express_gateway_service.ts
   - primary_task_set.ts
   - service.ts

--- a/model/aws/eks/extensions/models/nodegroup.ts
+++ b/model/aws/eks/extensions/models/nodegroup.ts
@@ -13,23 +13,23 @@ import {
 } from "./_lib/aws.ts";
 
 export const TaintSchema = z.object({
+  Key: z.string().min(1).optional(),
   Value: z.string().min(0).optional(),
   Effect: z.string().min(1).optional(),
-  Key: z.string().min(1).optional(),
 });
 
 export const NodeRepairConfigOverridesSchema = z.object({
+  NodeMonitoringCondition: z.string().describe(
+    "Specify an unhealthy condition reported by the node monitoring agent that this override would apply to.",
+  ).optional(),
   NodeUnhealthyReason: z.string().describe(
     "Specify a reason reported by the node monitoring agent that this override would apply to.",
-  ).optional(),
-  RepairAction: z.enum(["Replace", "Reboot", "NoAction"]).describe(
-    "Specify the repair action to take for nodes when all of the specified conditions are met.",
   ).optional(),
   MinRepairWaitTimeMins: z.number().int().min(1).describe(
     "Specify the minimum time in minutes to wait before attempting to repair a node with this specific NodeMonitoringCondition and NodeUnhealthyReason.",
   ).optional(),
-  NodeMonitoringCondition: z.string().describe(
-    "Specify an unhealthy condition reported by the node monitoring agent that this override would apply to.",
+  RepairAction: z.enum(["Replace", "Reboot", "NoAction"]).describe(
+    "Specify the repair action to take for nodes when all of the specified conditions are met.",
   ).optional(),
 });
 
@@ -37,80 +37,39 @@ const GlobalArgsSchema = z.object({
   name: z.string().describe(
     "Instance name for this resource (used as the unique identifier in the factory pattern)",
   ),
-  UpdateConfig: z.object({
-    MaxUnavailablePercentage: z.number().min(1).max(100).describe(
-      "The maximum percentage of nodes unavailable during a version update. This percentage of nodes will be updated in parallel, up to 100 nodes at once. This value or maxUnavailable is required to have a value.",
-    ).optional(),
-    UpdateStrategy: z.string().describe(
-      "The configuration for the behavior to follow during an node group version update of this managed node group. You choose between two possible strategies for replacing nodes during an UpdateNodegroupVersion action.",
-    ).optional(),
-    MaxUnavailable: z.number().min(1).describe(
-      "The maximum number of nodes unavailable at once during a version update. Nodes will be updated in parallel. This value or maxUnavailablePercentage is required to have a value.The maximum number is 100.",
-    ).optional(),
-  }).describe("The node group update configuration.").optional(),
-  ScalingConfig: z.object({
-    MinSize: z.number().int().min(0).optional(),
-    DesiredSize: z.number().int().min(0).optional(),
-    MaxSize: z.number().int().min(1).optional(),
-  }).describe(
-    "The scaling configuration details for the Auto Scaling group that is created for your node group.",
-  ).optional(),
-  Labels: z.record(z.string(), z.string()).describe(
-    "The Kubernetes labels to be applied to the nodes in the node group when they are created.",
-  ).optional(),
-  Taints: z.array(TaintSchema).describe(
-    "The Kubernetes taints to be applied to the nodes in the node group when they are created.",
-  ).optional(),
+  AmiType: z.string().describe("The AMI type for your node group.").optional(),
   CapacityType: z.string().describe(
     "The capacity type of your managed node group.",
   ).optional(),
-  ReleaseVersion: z.string().describe(
-    "The AMI version of the Amazon EKS-optimized AMI to use with your node group.",
-  ).optional(),
-  NodeRepairConfig: z.object({
-    NodeRepairConfigOverrides: z.array(NodeRepairConfigOverridesSchema)
-      .describe(
-        "Specify granular overrides for specific repair actions. These overrides control the repair action and the repair delay time before a node is considered eligible for repair. If you use this, you must specify all the values.",
-      ).optional(),
-    MaxParallelNodesRepairedCount: z.number().int().min(1).describe(
-      "Specify the maximum number of nodes that can be repaired concurrently or in parallel, expressed as a count of unhealthy nodes. This gives you finer-grained control over the pace of node replacements. When using this, you cannot also set MaxParallelNodesRepairedPercentage at the same time.",
-    ).optional(),
-    Enabled: z.boolean().describe(
-      "Set this value to true to enable node auto repair for the node group.",
-    ).optional(),
-    MaxUnhealthyNodeThresholdPercentage: z.number().int().min(1).max(100)
-      .describe(
-        "Specify a percentage threshold of unhealthy nodes, above which node auto repair actions will stop. When using this, you cannot also set MaxUnhealthyNodeThresholdCount at the same time.",
-      ).optional(),
-    MaxParallelNodesRepairedPercentage: z.number().int().min(1).max(100)
-      .describe(
-        "Specify the maximum number of nodes that can be repaired concurrently or in parallel, expressed as a percentage of unhealthy nodes. This gives you finer-grained control over the pace of node replacements. When using this, you cannot also set MaxParallelNodesRepairedCount at the same time.",
-      ).optional(),
-    MaxUnhealthyNodeThresholdCount: z.number().int().min(1).describe(
-      "Specify a count threshold of unhealthy nodes, above which node auto repair actions will stop. When using this, you cannot also set MaxUnhealthyNodeThresholdPercentage at the same time.",
-    ).optional(),
-  }).describe("The node auto repair configuration for node group.").optional(),
-  NodegroupName: z.string().min(1).describe(
-    "The unique name to give your node group.",
-  ).optional(),
-  NodeRole: z.string().describe(
-    "The Amazon Resource Name (ARN) of the IAM role to associate with your node group.",
+  ClusterName: z.string().min(1).describe(
+    "Name of the cluster to create the node group in.",
   ),
-  Subnets: z.array(z.string()).describe(
-    "The subnets to use for the Auto Scaling group that is created for your node group.",
-  ),
-  AmiType: z.string().describe("The AMI type for your node group.").optional(),
+  DiskSize: z.number().int().describe(
+    "The root device disk size (in GiB) for your node group instances.",
+  ).optional(),
   ForceUpdateEnabled: z.boolean().describe(
     "Force the update if the existing node group's pods are unable to be drained due to a pod disruption budget issue.",
   ).optional(),
-  Version: z.string().describe(
-    "The Kubernetes version to use for your managed nodes.",
+  InstanceTypes: z.array(z.string()).describe(
+    "Specify the instance types for a node group.",
+  ).optional(),
+  Labels: z.record(z.string(), z.string()).describe(
+    "The Kubernetes labels to be applied to the nodes in the node group when they are created.",
   ).optional(),
   LaunchTemplate: z.object({
     Version: z.string().min(1).optional(),
     Name: z.string().min(1).optional(),
   }).describe(
     "An object representing a node group's launch template specification.",
+  ).optional(),
+  NodegroupName: z.string().min(1).describe(
+    "The unique name to give your node group.",
+  ).optional(),
+  NodeRole: z.string().describe(
+    "The Amazon Resource Name (ARN) of the IAM role to associate with your node group.",
+  ),
+  ReleaseVersion: z.string().describe(
+    "The AMI version of the Amazon EKS-optimized AMI to use with your node group.",
   ).optional(),
   RemoteAccess: z.object({
     SourceSecurityGroups: z.array(z.string()).optional(),
@@ -118,81 +77,6 @@ const GlobalArgsSchema = z.object({
   }).describe(
     "The remote access (SSH) configuration to use with your node group.",
   ).optional(),
-  DiskSize: z.number().int().describe(
-    "The root device disk size (in GiB) for your node group instances.",
-  ).optional(),
-  ClusterName: z.string().min(1).describe(
-    "Name of the cluster to create the node group in.",
-  ),
-  InstanceTypes: z.array(z.string()).describe(
-    "Specify the instance types for a node group.",
-  ).optional(),
-  Tags: z.record(z.string(), z.string()).describe(
-    "The metadata, as key-value pairs, to apply to the node group to assist with categorization and organization. Follows same schema as Labels for consistency.",
-  ).optional(),
-});
-
-const StateSchema = z.object({
-  UpdateConfig: z.object({
-    MaxUnavailablePercentage: z.number(),
-    UpdateStrategy: z.string(),
-    MaxUnavailable: z.number(),
-  }).optional(),
-  ScalingConfig: z.object({
-    MinSize: z.number(),
-    DesiredSize: z.number(),
-    MaxSize: z.number(),
-  }).optional(),
-  Labels: z.record(z.string(), z.unknown()).optional(),
-  Taints: z.array(TaintSchema).optional(),
-  CapacityType: z.string().optional(),
-  ReleaseVersion: z.string().optional(),
-  NodeRepairConfig: z.object({
-    NodeRepairConfigOverrides: z.array(NodeRepairConfigOverridesSchema),
-    MaxParallelNodesRepairedCount: z.number(),
-    Enabled: z.boolean(),
-    MaxUnhealthyNodeThresholdPercentage: z.number(),
-    MaxParallelNodesRepairedPercentage: z.number(),
-    MaxUnhealthyNodeThresholdCount: z.number(),
-  }).optional(),
-  NodegroupName: z.string().optional(),
-  NodeRole: z.string().optional(),
-  Subnets: z.array(z.string()).optional(),
-  AmiType: z.string().optional(),
-  ForceUpdateEnabled: z.boolean().optional(),
-  Version: z.string().optional(),
-  LaunchTemplate: z.object({
-    Version: z.string(),
-    Id: z.string(),
-    Name: z.string(),
-  }).optional(),
-  RemoteAccess: z.object({
-    SourceSecurityGroups: z.array(z.string()),
-    Ec2SshKey: z.string(),
-  }).optional(),
-  DiskSize: z.number().optional(),
-  ClusterName: z.string().optional(),
-  InstanceTypes: z.array(z.string()).optional(),
-  Id: z.string(),
-  Arn: z.string().optional(),
-  Tags: z.record(z.string(), z.unknown()).optional(),
-}).passthrough();
-
-type StateData = z.infer<typeof StateSchema>;
-
-const InputsSchema = z.object({
-  name: z.string().optional(),
-  UpdateConfig: z.object({
-    MaxUnavailablePercentage: z.number().min(1).max(100).describe(
-      "The maximum percentage of nodes unavailable during a version update. This percentage of nodes will be updated in parallel, up to 100 nodes at once. This value or maxUnavailable is required to have a value.",
-    ).optional(),
-    UpdateStrategy: z.string().describe(
-      "The configuration for the behavior to follow during an node group version update of this managed node group. You choose between two possible strategies for replacing nodes during an UpdateNodegroupVersion action.",
-    ).optional(),
-    MaxUnavailable: z.number().min(1).describe(
-      "The maximum number of nodes unavailable at once during a version update. Nodes will be updated in parallel. This value or maxUnavailablePercentage is required to have a value.The maximum number is 100.",
-    ).optional(),
-  }).describe("The node group update configuration.").optional(),
   ScalingConfig: z.object({
     MinSize: z.number().int().min(0).optional(),
     DesiredSize: z.number().int().min(0).optional(),
@@ -200,62 +84,162 @@ const InputsSchema = z.object({
   }).describe(
     "The scaling configuration details for the Auto Scaling group that is created for your node group.",
   ).optional(),
-  Labels: z.record(z.string(), z.string()).describe(
-    "The Kubernetes labels to be applied to the nodes in the node group when they are created.",
+  Subnets: z.array(z.string()).describe(
+    "The subnets to use for the Auto Scaling group that is created for your node group.",
+  ),
+  Tags: z.record(z.string(), z.string()).describe(
+    "The metadata, as key-value pairs, to apply to the node group to assist with categorization and organization. Follows same schema as Labels for consistency.",
   ).optional(),
   Taints: z.array(TaintSchema).describe(
     "The Kubernetes taints to be applied to the nodes in the node group when they are created.",
   ).optional(),
-  CapacityType: z.string().describe(
-    "The capacity type of your managed node group.",
-  ).optional(),
-  ReleaseVersion: z.string().describe(
-    "The AMI version of the Amazon EKS-optimized AMI to use with your node group.",
-  ).optional(),
-  NodeRepairConfig: z.object({
-    NodeRepairConfigOverrides: z.array(NodeRepairConfigOverridesSchema)
-      .describe(
-        "Specify granular overrides for specific repair actions. These overrides control the repair action and the repair delay time before a node is considered eligible for repair. If you use this, you must specify all the values.",
-      ).optional(),
-    MaxParallelNodesRepairedCount: z.number().int().min(1).describe(
-      "Specify the maximum number of nodes that can be repaired concurrently or in parallel, expressed as a count of unhealthy nodes. This gives you finer-grained control over the pace of node replacements. When using this, you cannot also set MaxParallelNodesRepairedPercentage at the same time.",
+  UpdateConfig: z.object({
+    UpdateStrategy: z.string().describe(
+      "The configuration for the behavior to follow during an node group version update of this managed node group. You choose between two possible strategies for replacing nodes during an UpdateNodegroupVersion action.",
     ).optional(),
+    MaxUnavailable: z.number().min(1).describe(
+      "The maximum number of nodes unavailable at once during a version update. Nodes will be updated in parallel. This value or maxUnavailablePercentage is required to have a value.The maximum number is 100.",
+    ).optional(),
+    MaxUnavailablePercentage: z.number().min(1).max(100).describe(
+      "The maximum percentage of nodes unavailable during a version update. This percentage of nodes will be updated in parallel, up to 100 nodes at once. This value or maxUnavailable is required to have a value.",
+    ).optional(),
+  }).describe("The node group update configuration.").optional(),
+  NodeRepairConfig: z.object({
     Enabled: z.boolean().describe(
       "Set this value to true to enable node auto repair for the node group.",
+    ).optional(),
+    MaxUnhealthyNodeThresholdCount: z.number().int().min(1).describe(
+      "Specify a count threshold of unhealthy nodes, above which node auto repair actions will stop. When using this, you cannot also set MaxUnhealthyNodeThresholdPercentage at the same time.",
     ).optional(),
     MaxUnhealthyNodeThresholdPercentage: z.number().int().min(1).max(100)
       .describe(
         "Specify a percentage threshold of unhealthy nodes, above which node auto repair actions will stop. When using this, you cannot also set MaxUnhealthyNodeThresholdCount at the same time.",
       ).optional(),
+    MaxParallelNodesRepairedCount: z.number().int().min(1).describe(
+      "Specify the maximum number of nodes that can be repaired concurrently or in parallel, expressed as a count of unhealthy nodes. This gives you finer-grained control over the pace of node replacements. When using this, you cannot also set MaxParallelNodesRepairedPercentage at the same time.",
+    ).optional(),
     MaxParallelNodesRepairedPercentage: z.number().int().min(1).max(100)
       .describe(
         "Specify the maximum number of nodes that can be repaired concurrently or in parallel, expressed as a percentage of unhealthy nodes. This gives you finer-grained control over the pace of node replacements. When using this, you cannot also set MaxParallelNodesRepairedCount at the same time.",
       ).optional(),
-    MaxUnhealthyNodeThresholdCount: z.number().int().min(1).describe(
-      "Specify a count threshold of unhealthy nodes, above which node auto repair actions will stop. When using this, you cannot also set MaxUnhealthyNodeThresholdPercentage at the same time.",
-    ).optional(),
+    NodeRepairConfigOverrides: z.array(NodeRepairConfigOverridesSchema)
+      .describe(
+        "Specify granular overrides for specific repair actions. These overrides control the repair action and the repair delay time before a node is considered eligible for repair. If you use this, you must specify all the values.",
+      ).optional(),
   }).describe("The node auto repair configuration for node group.").optional(),
-  NodegroupName: z.string().min(1).describe(
-    "The unique name to give your node group.",
-  ).optional(),
-  NodeRole: z.string().describe(
-    "The Amazon Resource Name (ARN) of the IAM role to associate with your node group.",
-  ).optional(),
-  Subnets: z.array(z.string()).describe(
-    "The subnets to use for the Auto Scaling group that is created for your node group.",
-  ).optional(),
-  AmiType: z.string().describe("The AMI type for your node group.").optional(),
-  ForceUpdateEnabled: z.boolean().describe(
-    "Force the update if the existing node group's pods are unable to be drained due to a pod disruption budget issue.",
+  WarmPoolConfig: z.object({
+    Enabled: z.boolean().describe(
+      "Enable or disable warm pool for the node group.",
+    ).optional(),
+    MaxGroupPreparedCapacity: z.number().int().min(-1).describe(
+      "The maximum number of instances that are allowed to be in the warm pool.",
+    ).optional(),
+    MinSize: z.number().int().min(0).describe(
+      "The minimum number of instances to maintain in the warm pool.",
+    ).optional(),
+    PoolState: z.string().describe("The desired state of warm pool instances.")
+      .optional(),
+    ReuseOnScaleIn: z.boolean().describe(
+      "Whether to return instances to the warm pool during scale-in instead of terminating them.",
+    ).optional(),
+  }).describe(
+    "The warm pool configuration details for the Auto Scaling group that is created for the node group.",
   ).optional(),
   Version: z.string().describe(
     "The Kubernetes version to use for your managed nodes.",
+  ).optional(),
+});
+
+const StateSchema = z.object({
+  AmiType: z.string().optional(),
+  CapacityType: z.string().optional(),
+  ClusterName: z.string().optional(),
+  DiskSize: z.number().optional(),
+  ForceUpdateEnabled: z.boolean().optional(),
+  InstanceTypes: z.array(z.string()).optional(),
+  Labels: z.record(z.string(), z.unknown()).optional(),
+  LaunchTemplate: z.object({
+    Id: z.string(),
+    Version: z.string(),
+    Name: z.string(),
+  }).optional(),
+  NodegroupName: z.string().optional(),
+  NodeRole: z.string().optional(),
+  ReleaseVersion: z.string().optional(),
+  RemoteAccess: z.object({
+    SourceSecurityGroups: z.array(z.string()),
+    Ec2SshKey: z.string(),
+  }).optional(),
+  ScalingConfig: z.object({
+    MinSize: z.number(),
+    DesiredSize: z.number(),
+    MaxSize: z.number(),
+  }).optional(),
+  Subnets: z.array(z.string()).optional(),
+  Tags: z.record(z.string(), z.unknown()).optional(),
+  Taints: z.array(TaintSchema).optional(),
+  UpdateConfig: z.object({
+    UpdateStrategy: z.string(),
+    MaxUnavailable: z.number(),
+    MaxUnavailablePercentage: z.number(),
+  }).optional(),
+  NodeRepairConfig: z.object({
+    Enabled: z.boolean(),
+    MaxUnhealthyNodeThresholdCount: z.number(),
+    MaxUnhealthyNodeThresholdPercentage: z.number(),
+    MaxParallelNodesRepairedCount: z.number(),
+    MaxParallelNodesRepairedPercentage: z.number(),
+    NodeRepairConfigOverrides: z.array(NodeRepairConfigOverridesSchema),
+  }).optional(),
+  WarmPoolConfig: z.object({
+    Enabled: z.boolean(),
+    MaxGroupPreparedCapacity: z.number(),
+    MinSize: z.number(),
+    PoolState: z.string(),
+    ReuseOnScaleIn: z.boolean(),
+  }).optional(),
+  Version: z.string().optional(),
+  Id: z.string(),
+  Arn: z.string().optional(),
+}).passthrough();
+
+type StateData = z.infer<typeof StateSchema>;
+
+const InputsSchema = z.object({
+  name: z.string().optional(),
+  AmiType: z.string().describe("The AMI type for your node group.").optional(),
+  CapacityType: z.string().describe(
+    "The capacity type of your managed node group.",
+  ).optional(),
+  ClusterName: z.string().min(1).describe(
+    "Name of the cluster to create the node group in.",
+  ).optional(),
+  DiskSize: z.number().int().describe(
+    "The root device disk size (in GiB) for your node group instances.",
+  ).optional(),
+  ForceUpdateEnabled: z.boolean().describe(
+    "Force the update if the existing node group's pods are unable to be drained due to a pod disruption budget issue.",
+  ).optional(),
+  InstanceTypes: z.array(z.string()).describe(
+    "Specify the instance types for a node group.",
+  ).optional(),
+  Labels: z.record(z.string(), z.string()).describe(
+    "The Kubernetes labels to be applied to the nodes in the node group when they are created.",
   ).optional(),
   LaunchTemplate: z.object({
     Version: z.string().min(1).optional(),
     Name: z.string().min(1).optional(),
   }).describe(
     "An object representing a node group's launch template specification.",
+  ).optional(),
+  NodegroupName: z.string().min(1).describe(
+    "The unique name to give your node group.",
+  ).optional(),
+  NodeRole: z.string().describe(
+    "The Amazon Resource Name (ARN) of the IAM role to associate with your node group.",
+  ).optional(),
+  ReleaseVersion: z.string().describe(
+    "The AMI version of the Amazon EKS-optimized AMI to use with your node group.",
   ).optional(),
   RemoteAccess: z.object({
     SourceSecurityGroups: z.array(z.string()).optional(),
@@ -263,23 +247,82 @@ const InputsSchema = z.object({
   }).describe(
     "The remote access (SSH) configuration to use with your node group.",
   ).optional(),
-  DiskSize: z.number().int().describe(
-    "The root device disk size (in GiB) for your node group instances.",
+  ScalingConfig: z.object({
+    MinSize: z.number().int().min(0).optional(),
+    DesiredSize: z.number().int().min(0).optional(),
+    MaxSize: z.number().int().min(1).optional(),
+  }).describe(
+    "The scaling configuration details for the Auto Scaling group that is created for your node group.",
   ).optional(),
-  ClusterName: z.string().min(1).describe(
-    "Name of the cluster to create the node group in.",
-  ).optional(),
-  InstanceTypes: z.array(z.string()).describe(
-    "Specify the instance types for a node group.",
+  Subnets: z.array(z.string()).describe(
+    "The subnets to use for the Auto Scaling group that is created for your node group.",
   ).optional(),
   Tags: z.record(z.string(), z.string()).describe(
     "The metadata, as key-value pairs, to apply to the node group to assist with categorization and organization. Follows same schema as Labels for consistency.",
+  ).optional(),
+  Taints: z.array(TaintSchema).describe(
+    "The Kubernetes taints to be applied to the nodes in the node group when they are created.",
+  ).optional(),
+  UpdateConfig: z.object({
+    UpdateStrategy: z.string().describe(
+      "The configuration for the behavior to follow during an node group version update of this managed node group. You choose between two possible strategies for replacing nodes during an UpdateNodegroupVersion action.",
+    ).optional(),
+    MaxUnavailable: z.number().min(1).describe(
+      "The maximum number of nodes unavailable at once during a version update. Nodes will be updated in parallel. This value or maxUnavailablePercentage is required to have a value.The maximum number is 100.",
+    ).optional(),
+    MaxUnavailablePercentage: z.number().min(1).max(100).describe(
+      "The maximum percentage of nodes unavailable during a version update. This percentage of nodes will be updated in parallel, up to 100 nodes at once. This value or maxUnavailable is required to have a value.",
+    ).optional(),
+  }).describe("The node group update configuration.").optional(),
+  NodeRepairConfig: z.object({
+    Enabled: z.boolean().describe(
+      "Set this value to true to enable node auto repair for the node group.",
+    ).optional(),
+    MaxUnhealthyNodeThresholdCount: z.number().int().min(1).describe(
+      "Specify a count threshold of unhealthy nodes, above which node auto repair actions will stop. When using this, you cannot also set MaxUnhealthyNodeThresholdPercentage at the same time.",
+    ).optional(),
+    MaxUnhealthyNodeThresholdPercentage: z.number().int().min(1).max(100)
+      .describe(
+        "Specify a percentage threshold of unhealthy nodes, above which node auto repair actions will stop. When using this, you cannot also set MaxUnhealthyNodeThresholdCount at the same time.",
+      ).optional(),
+    MaxParallelNodesRepairedCount: z.number().int().min(1).describe(
+      "Specify the maximum number of nodes that can be repaired concurrently or in parallel, expressed as a count of unhealthy nodes. This gives you finer-grained control over the pace of node replacements. When using this, you cannot also set MaxParallelNodesRepairedPercentage at the same time.",
+    ).optional(),
+    MaxParallelNodesRepairedPercentage: z.number().int().min(1).max(100)
+      .describe(
+        "Specify the maximum number of nodes that can be repaired concurrently or in parallel, expressed as a percentage of unhealthy nodes. This gives you finer-grained control over the pace of node replacements. When using this, you cannot also set MaxParallelNodesRepairedCount at the same time.",
+      ).optional(),
+    NodeRepairConfigOverrides: z.array(NodeRepairConfigOverridesSchema)
+      .describe(
+        "Specify granular overrides for specific repair actions. These overrides control the repair action and the repair delay time before a node is considered eligible for repair. If you use this, you must specify all the values.",
+      ).optional(),
+  }).describe("The node auto repair configuration for node group.").optional(),
+  WarmPoolConfig: z.object({
+    Enabled: z.boolean().describe(
+      "Enable or disable warm pool for the node group.",
+    ).optional(),
+    MaxGroupPreparedCapacity: z.number().int().min(-1).describe(
+      "The maximum number of instances that are allowed to be in the warm pool.",
+    ).optional(),
+    MinSize: z.number().int().min(0).describe(
+      "The minimum number of instances to maintain in the warm pool.",
+    ).optional(),
+    PoolState: z.string().describe("The desired state of warm pool instances.")
+      .optional(),
+    ReuseOnScaleIn: z.boolean().describe(
+      "Whether to return instances to the warm pool during scale-in instead of terminating them.",
+    ).optional(),
+  }).describe(
+    "The warm pool configuration details for the Auto Scaling group that is created for the node group.",
+  ).optional(),
+  Version: z.string().describe(
+    "The Kubernetes version to use for your managed nodes.",
   ).optional(),
 });
 
 export const model = {
   type: "@swamp/aws/eks/nodegroup",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.03.27.1",
@@ -291,8 +334,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "Added: WarmPoolConfig",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/eks/manifest.yaml
+++ b/model/aws/eks/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/eks"
-version: "2026.04.01.1"
+version: "2026.04.03.1"
 description: "AWS EKS infrastructure models"
 labels:
   - aws

--- a/model/aws/elasticloadbalancing/LICENSE.txt
+++ b/model/aws/elasticloadbalancing/LICENSE.txt
@@ -1,0 +1,14 @@
+Copyright (C) 2026 System Initiative, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/model/aws/elasticloadbalancing/README.md
+++ b/model/aws/elasticloadbalancing/README.md
@@ -1,0 +1,66 @@
+# @swamp/aws/elasticloadbalancing
+
+Auto-generated [swamp](https://github.com/systeminit/swamp) extension models for
+AWS ELASTICLOADBALANCING resources.
+
+Each model represents a single AWS resource (e.g., a VPC, an S3 bucket, an IAM
+role). Models have **domain properties** that you configure (the desired state)
+and **resource properties** that reflect the live state in AWS. Available
+methods:
+
+- **create** — provision the resource in AWS using the configured properties
+- **get** — fetch the current state of a specific resource by identifier
+- **update** — apply property changes to an existing resource
+- **delete** — remove the resource from AWS
+- **sync** — refresh all resource properties from AWS
+
+Use `swamp model type describe @swamp/aws/elasticloadbalancing/load_balancer` to
+see the full list of configurable properties and available methods for this
+model.
+
+## Authentication
+
+These models use the AWS SDK v3 default credential chain. Credentials are
+resolved in the following order:
+
+1. **Environment variables** — `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` +
+   optional `AWS_SESSION_TOKEN`
+2. **SSO credentials** — `aws sso login`
+3. **Shared credentials file** — `~/.aws/credentials`
+4. **Shared config file** — `~/.aws/config` (profiles, `credential_process`,
+   SSO)
+5. **ECS container credentials** — task IAM role
+6. **EC2 instance metadata** — instance profile
+
+### Region
+
+The `AWS_REGION` environment variable controls which region resources are
+created and managed in. Defaults to `us-east-1` if not set.
+
+### Setup
+
+```bash
+export AWS_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=wJal...
+```
+
+## Usage
+
+```bash
+# Create a new load_balancer model
+swamp model create @swamp/aws/elasticloadbalancing/load_balancer my-load_balancer
+
+# Edit the model to configure its properties
+swamp model edit my-load_balancer
+
+# Create the resource in AWS
+swamp model method run my-load_balancer create
+
+# Sync current state from AWS
+swamp model method run my-load_balancer sync
+```
+
+## License
+
+AGPLv3 — see [LICENSE.txt](./LICENSE.txt).

--- a/model/aws/elasticloadbalancing/deno.json
+++ b/model/aws/elasticloadbalancing/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "zod": "npm:zod@4.3.6",
+    "@aws-sdk/client-cloudcontrol": "npm:@aws-sdk/client-cloudcontrol@3.1021.0",
+    "fast-json-patch": "npm:fast-json-patch@3.1.1"
+  }
+}

--- a/model/aws/elasticloadbalancing/deno.lock
+++ b/model/aws/elasticloadbalancing/deno.lock
@@ -1,0 +1,776 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@aws-sdk/client-cloudcontrol@3.1021.0": "3.1021.0",
+    "npm:fast-json-patch@3.1.1": "3.1.1",
+    "npm:zod@4.3.6": "4.3.6"
+  },
+  "npm": {
+    "@aws-crypto/sha256-browser@5.2.0": {
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dependencies": [
+        "@aws-crypto/sha256-js",
+        "@aws-crypto/supports-web-crypto",
+        "@aws-crypto/util",
+        "@aws-sdk/types",
+        "@aws-sdk/util-locate-window",
+        "@smithy/util-utf8@2.3.0",
+        "tslib"
+      ]
+    },
+    "@aws-crypto/sha256-js@5.2.0": {
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dependencies": [
+        "@aws-crypto/util",
+        "@aws-sdk/types",
+        "tslib"
+      ]
+    },
+    "@aws-crypto/supports-web-crypto@5.2.0": {
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@aws-crypto/util@5.2.0": {
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/util-utf8@2.3.0",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/client-cloudcontrol@3.1021.0": {
+      "integrity": "sha512-VbrIC3iT4OveHdkjYdMdwGk60YNOmN0OsL1QEuEjOwUmjq1aYRzgtjNb9fGR9a8CWhGA7yjqWDaUeNJ+wUGzMw==",
+      "dependencies": [
+        "@aws-crypto/sha256-browser",
+        "@aws-crypto/sha256-js",
+        "@aws-sdk/core",
+        "@aws-sdk/credential-provider-node",
+        "@aws-sdk/middleware-host-header",
+        "@aws-sdk/middleware-logger",
+        "@aws-sdk/middleware-recursion-detection",
+        "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/region-config-resolver",
+        "@aws-sdk/types",
+        "@aws-sdk/util-endpoints",
+        "@aws-sdk/util-user-agent-browser",
+        "@aws-sdk/util-user-agent-node",
+        "@smithy/config-resolver",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/hash-node",
+        "@smithy/invalid-dependency",
+        "@smithy/middleware-content-length",
+        "@smithy/middleware-endpoint",
+        "@smithy/middleware-retry",
+        "@smithy/middleware-serde",
+        "@smithy/middleware-stack",
+        "@smithy/node-config-provider",
+        "@smithy/node-http-handler",
+        "@smithy/protocol-http",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-base64",
+        "@smithy/util-body-length-browser",
+        "@smithy/util-body-length-node",
+        "@smithy/util-defaults-mode-browser",
+        "@smithy/util-defaults-mode-node",
+        "@smithy/util-endpoints",
+        "@smithy/util-middleware",
+        "@smithy/util-retry",
+        "@smithy/util-utf8@4.2.2",
+        "@smithy/util-waiter",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/core@3.973.26": {
+      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@aws-sdk/xml-builder",
+        "@smithy/core",
+        "@smithy/node-config-provider",
+        "@smithy/property-provider",
+        "@smithy/protocol-http",
+        "@smithy/signature-v4",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/util-base64",
+        "@smithy/util-middleware",
+        "@smithy/util-utf8@4.2.2",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-env@3.972.24": {
+      "integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-http@3.972.26": {
+      "integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/fetch-http-handler",
+        "@smithy/node-http-handler",
+        "@smithy/property-provider",
+        "@smithy/protocol-http",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/util-stream",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-ini@3.972.28": {
+      "integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/credential-provider-env",
+        "@aws-sdk/credential-provider-http",
+        "@aws-sdk/credential-provider-login",
+        "@aws-sdk/credential-provider-process",
+        "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-web-identity",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/credential-provider-imds",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-login@3.972.28": {
+      "integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/protocol-http",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-node@3.972.29": {
+      "integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
+      "dependencies": [
+        "@aws-sdk/credential-provider-env",
+        "@aws-sdk/credential-provider-http",
+        "@aws-sdk/credential-provider-ini",
+        "@aws-sdk/credential-provider-process",
+        "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-web-identity",
+        "@aws-sdk/types",
+        "@smithy/credential-provider-imds",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-process@3.972.24": {
+      "integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-sso@3.972.28": {
+      "integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/token-providers",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-web-identity@3.972.28": {
+      "integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-host-header@3.972.8": {
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-logger@3.972.8": {
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-recursion-detection@3.972.9": {
+      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@aws/lambda-invoke-store",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-user-agent@3.972.28": {
+      "integrity": "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@aws-sdk/util-endpoints",
+        "@smithy/core",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "@smithy/util-retry",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/nested-clients@3.996.18": {
+      "integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
+      "dependencies": [
+        "@aws-crypto/sha256-browser",
+        "@aws-crypto/sha256-js",
+        "@aws-sdk/core",
+        "@aws-sdk/middleware-host-header",
+        "@aws-sdk/middleware-logger",
+        "@aws-sdk/middleware-recursion-detection",
+        "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/region-config-resolver",
+        "@aws-sdk/types",
+        "@aws-sdk/util-endpoints",
+        "@aws-sdk/util-user-agent-browser",
+        "@aws-sdk/util-user-agent-node",
+        "@smithy/config-resolver",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/hash-node",
+        "@smithy/invalid-dependency",
+        "@smithy/middleware-content-length",
+        "@smithy/middleware-endpoint",
+        "@smithy/middleware-retry",
+        "@smithy/middleware-serde",
+        "@smithy/middleware-stack",
+        "@smithy/node-config-provider",
+        "@smithy/node-http-handler",
+        "@smithy/protocol-http",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-base64",
+        "@smithy/util-body-length-browser",
+        "@smithy/util-body-length-node",
+        "@smithy/util-defaults-mode-browser",
+        "@smithy/util-defaults-mode-node",
+        "@smithy/util-endpoints",
+        "@smithy/util-middleware",
+        "@smithy/util-retry",
+        "@smithy/util-utf8@4.2.2",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/region-config-resolver@3.972.10": {
+      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/config-resolver",
+        "@smithy/node-config-provider",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/token-providers@3.1021.0": {
+      "integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/types@3.973.6": {
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/util-endpoints@3.996.5": {
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-endpoints",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/util-locate-window@3.965.5": {
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@aws-sdk/util-user-agent-browser@3.972.8": {
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/types",
+        "bowser",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/util-user-agent-node@3.973.14": {
+      "integrity": "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==",
+      "dependencies": [
+        "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/types",
+        "@smithy/node-config-provider",
+        "@smithy/types",
+        "@smithy/util-config-provider",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/xml-builder@3.972.16": {
+      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "dependencies": [
+        "@smithy/types",
+        "fast-xml-parser",
+        "tslib"
+      ]
+    },
+    "@aws/lambda-invoke-store@0.2.4": {
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="
+    },
+    "@smithy/config-resolver@4.4.13": {
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+      "dependencies": [
+        "@smithy/node-config-provider",
+        "@smithy/types",
+        "@smithy/util-config-provider",
+        "@smithy/util-endpoints",
+        "@smithy/util-middleware",
+        "tslib"
+      ]
+    },
+    "@smithy/core@3.23.13": {
+      "integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
+      "dependencies": [
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-base64",
+        "@smithy/util-body-length-browser",
+        "@smithy/util-middleware",
+        "@smithy/util-stream",
+        "@smithy/util-utf8@4.2.2",
+        "@smithy/uuid",
+        "tslib"
+      ]
+    },
+    "@smithy/credential-provider-imds@4.2.12": {
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "dependencies": [
+        "@smithy/node-config-provider",
+        "@smithy/property-provider",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "tslib"
+      ]
+    },
+    "@smithy/fetch-http-handler@5.3.15": {
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "dependencies": [
+        "@smithy/protocol-http",
+        "@smithy/querystring-builder",
+        "@smithy/types",
+        "@smithy/util-base64",
+        "tslib"
+      ]
+    },
+    "@smithy/hash-node@4.2.12": {
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+      "dependencies": [
+        "@smithy/types",
+        "@smithy/util-buffer-from@4.2.2",
+        "@smithy/util-utf8@4.2.2",
+        "tslib"
+      ]
+    },
+    "@smithy/invalid-dependency@4.2.12": {
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/is-array-buffer@2.2.0": {
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/is-array-buffer@4.2.2": {
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-content-length@4.2.12": {
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+      "dependencies": [
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-endpoint@4.4.28": {
+      "integrity": "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/middleware-serde",
+        "@smithy/node-config-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-middleware",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-retry@4.4.46": {
+      "integrity": "sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==",
+      "dependencies": [
+        "@smithy/node-config-provider",
+        "@smithy/protocol-http",
+        "@smithy/service-error-classification",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/util-middleware",
+        "@smithy/util-retry",
+        "@smithy/uuid",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-serde@4.2.16": {
+      "integrity": "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-stack@4.2.12": {
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/node-config-provider@4.3.12": {
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+      "dependencies": [
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/node-http-handler@4.5.1": {
+      "integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
+      "dependencies": [
+        "@smithy/protocol-http",
+        "@smithy/querystring-builder",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/property-provider@4.2.12": {
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/protocol-http@5.3.12": {
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/querystring-builder@4.2.12": {
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+      "dependencies": [
+        "@smithy/types",
+        "@smithy/util-uri-escape",
+        "tslib"
+      ]
+    },
+    "@smithy/querystring-parser@4.2.12": {
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/service-error-classification@4.2.12": {
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+      "dependencies": [
+        "@smithy/types"
+      ]
+    },
+    "@smithy/shared-ini-file-loader@4.4.7": {
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/signature-v4@5.3.12": {
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "dependencies": [
+        "@smithy/is-array-buffer@4.2.2",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "@smithy/util-hex-encoding",
+        "@smithy/util-middleware",
+        "@smithy/util-uri-escape",
+        "@smithy/util-utf8@4.2.2",
+        "tslib"
+      ]
+    },
+    "@smithy/smithy-client@4.12.8": {
+      "integrity": "sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/middleware-endpoint",
+        "@smithy/middleware-stack",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "@smithy/util-stream",
+        "tslib"
+      ]
+    },
+    "@smithy/types@4.13.1": {
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/url-parser@4.2.12": {
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+      "dependencies": [
+        "@smithy/querystring-parser",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-base64@4.3.2": {
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "dependencies": [
+        "@smithy/util-buffer-from@4.2.2",
+        "@smithy/util-utf8@4.2.2",
+        "tslib"
+      ]
+    },
+    "@smithy/util-body-length-browser@4.2.2": {
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-body-length-node@4.2.3": {
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-buffer-from@2.2.0": {
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": [
+        "@smithy/is-array-buffer@2.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/util-buffer-from@4.2.2": {
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "dependencies": [
+        "@smithy/is-array-buffer@4.2.2",
+        "tslib"
+      ]
+    },
+    "@smithy/util-config-provider@4.2.2": {
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-defaults-mode-browser@4.3.44": {
+      "integrity": "sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==",
+      "dependencies": [
+        "@smithy/property-provider",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-defaults-mode-node@4.2.48": {
+      "integrity": "sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==",
+      "dependencies": [
+        "@smithy/config-resolver",
+        "@smithy/credential-provider-imds",
+        "@smithy/node-config-provider",
+        "@smithy/property-provider",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-endpoints@3.3.3": {
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+      "dependencies": [
+        "@smithy/node-config-provider",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-hex-encoding@4.2.2": {
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-middleware@4.2.12": {
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-retry@4.2.13": {
+      "integrity": "sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==",
+      "dependencies": [
+        "@smithy/service-error-classification",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-stream@4.5.21": {
+      "integrity": "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==",
+      "dependencies": [
+        "@smithy/fetch-http-handler",
+        "@smithy/node-http-handler",
+        "@smithy/types",
+        "@smithy/util-base64",
+        "@smithy/util-buffer-from@4.2.2",
+        "@smithy/util-hex-encoding",
+        "@smithy/util-utf8@4.2.2",
+        "tslib"
+      ]
+    },
+    "@smithy/util-uri-escape@4.2.2": {
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-utf8@2.3.0": {
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": [
+        "@smithy/util-buffer-from@2.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/util-utf8@4.2.2": {
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "dependencies": [
+        "@smithy/util-buffer-from@4.2.2",
+        "tslib"
+      ]
+    },
+    "@smithy/util-waiter@4.2.14": {
+      "integrity": "sha512-2zqq5o/oizvMaFUlNiTyZ7dbgYv1a893aGut2uaxtbzTx/VYYnRxWzDHuD/ftgcw94ffenua+ZNLrbqwUYE+Bg==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/uuid@1.1.2": {
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "bowser@2.14.1": {
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
+    },
+    "fast-json-patch@3.1.1": {
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
+    },
+    "fast-xml-builder@1.1.4": {
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "dependencies": [
+        "path-expression-matcher"
+      ]
+    },
+    "fast-xml-parser@5.5.8": {
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "dependencies": [
+        "fast-xml-builder",
+        "path-expression-matcher",
+        "strnum"
+      ],
+      "bin": true
+    },
+    "path-expression-matcher@1.2.1": {
+      "integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw=="
+    },
+    "strnum@2.2.2": {
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "zod@4.3.6": {
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@aws-sdk/client-cloudcontrol@3.1021.0",
+      "npm:fast-json-patch@3.1.1",
+      "npm:zod@4.3.6"
+    ]
+  }
+}

--- a/model/aws/elasticloadbalancing/extensions/models/_lib/aws.ts
+++ b/model/aws/elasticloadbalancing/extensions/models/_lib/aws.ts
@@ -1,0 +1,395 @@
+// Auto-generated shared helper for AWS CloudControl extension models.
+// Do not edit manually. Re-generate with: deno task generate:aws
+
+import {
+  CloudControlClient,
+  CreateResourceCommand,
+  DeleteResourceCommand,
+  GetResourceCommand,
+  GetResourceRequestStatusCommand,
+  UpdateResourceCommand,
+} from "@aws-sdk/client-cloudcontrol";
+import jsonpatch from "fast-json-patch";
+
+function createClient(): CloudControlClient {
+  return new CloudControlClient({
+    region: Deno.env.get("AWS_REGION") || "us-east-1",
+  });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isThrottlingError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  const name = error instanceof Error ? error.name : "";
+  return (
+    msg.includes("Throttling") ||
+    msg.includes("TooManyRequests") ||
+    msg.includes("RequestLimitExceeded") ||
+    name === "ThrottlingException"
+  );
+}
+
+export function isResourceNotFoundError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  const name = error instanceof Error ? error.name : "";
+  return (
+    msg.includes("was not found") ||
+    msg.includes("does not exist") ||
+    name === "ResourceNotFoundException"
+  );
+}
+
+async function withRetry<T>(
+  operation: () => Promise<T>,
+  operationName: string,
+  maxAttempts = 20,
+): Promise<T> {
+  const baseDelay = 1000;
+  const maxDelay = 90000;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (isThrottlingError(error) && attempt < maxAttempts - 1) {
+        const exponentialDelay = Math.min(
+          baseDelay * Math.pow(2, attempt),
+          maxDelay,
+        );
+        const jitter = Math.random() * 0.3 * exponentialDelay;
+        console.log(
+          `[${operationName}] Throttled on attempt ${attempt + 1}, waiting ${
+            Math.round(exponentialDelay + jitter)
+          }ms`,
+        );
+        await delay(exponentialDelay + jitter);
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error(`${operationName} failed after ${maxAttempts} attempts`);
+}
+
+async function pollOperationStatus(
+  client: CloudControlClient,
+  requestToken: string,
+  operationName: string,
+): Promise<{ status: string; identifier?: string; message?: string }> {
+  const baseDelay = 1000;
+  const maxDelay = 90000;
+
+  for (let attempt = 0; attempt < 60; attempt++) {
+    const response = await withRetry(
+      () =>
+        client.send(
+          new GetResourceRequestStatusCommand({
+            RequestToken: requestToken,
+          }),
+        ),
+      `${operationName} status poll`,
+    );
+
+    const status = response.ProgressEvent?.OperationStatus;
+    if (status === "SUCCESS") {
+      return {
+        status: "SUCCESS",
+        identifier: response.ProgressEvent?.Identifier,
+      };
+    }
+    if (status === "FAILED") {
+      return {
+        status: "FAILED",
+        message: response.ProgressEvent?.StatusMessage ||
+          response.ProgressEvent?.ErrorCode,
+      };
+    }
+    if (status === "CANCEL_COMPLETE") {
+      return {
+        status: "CANCEL_COMPLETE",
+        message: "Operation cancelled by API or AWS",
+      };
+    }
+
+    const exponentialDelay = Math.min(
+      baseDelay * Math.pow(2, attempt),
+      maxDelay,
+    );
+    const jitter = Math.random() * 0.3 * exponentialDelay;
+    console.log(
+      `[${operationName}] IN_PROGRESS, waiting ${
+        Math.round(exponentialDelay + jitter)
+      }ms (poll ${attempt + 1})`,
+    );
+    await delay(exponentialDelay + jitter);
+  }
+
+  throw new Error(`${operationName} timed out after polling`);
+}
+
+/**
+ * Create an AWS resource via CloudControl API.
+ * Sends CreateResourceCommand, polls until complete, then reads the resource.
+ * Returns the resource properties.
+ */
+export async function createResource(
+  typeName: string,
+  desiredState: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const client = createClient();
+
+  console.log(`[CREATE] Starting create for ${typeName}`);
+
+  const response = await withRetry(
+    () =>
+      client.send(
+        new CreateResourceCommand({
+          TypeName: typeName,
+          DesiredState: JSON.stringify(desiredState),
+        }),
+      ),
+    `${typeName} create`,
+  );
+
+  if (!response.ProgressEvent?.RequestToken) {
+    throw new Error(`${typeName} creation failed: no request token returned`);
+  }
+
+  const requestToken = response.ProgressEvent.RequestToken;
+  console.log(`[CREATE] Got request token: ${requestToken}`);
+
+  const pollResult = await pollOperationStatus(
+    client,
+    requestToken,
+    `${typeName} create`,
+  );
+
+  if (pollResult.status === "FAILED") {
+    throw new Error(
+      `${typeName} creation failed: ${pollResult.message || "Unknown error"}`,
+    );
+  }
+  if (pollResult.status === "CANCEL_COMPLETE") {
+    throw new Error(
+      `${typeName} creation cancelled: ${pollResult.message}`,
+    );
+  }
+
+  const identifier = pollResult.identifier;
+  if (!identifier) {
+    throw new Error(
+      `${typeName} creation succeeded but no identifier returned`,
+    );
+  }
+
+  console.log(`[CREATE] Success, fetching resource ${identifier}`);
+
+  const getResponse = await withRetry(
+    () =>
+      client.send(
+        new GetResourceCommand({
+          TypeName: typeName,
+          Identifier: identifier,
+        }),
+      ),
+    `${typeName} create get-resource`,
+  );
+
+  if (!getResponse.ResourceDescription?.Properties) {
+    throw new Error(`Failed to get ${typeName} details after creation`);
+  }
+
+  return JSON.parse(getResponse.ResourceDescription.Properties);
+}
+
+/**
+ * Read an AWS resource via CloudControl API.
+ * Returns the resource properties, or throws if not found.
+ */
+export async function readResource(
+  typeName: string,
+  identifier: string,
+): Promise<Record<string, unknown>> {
+  const client = createClient();
+
+  console.log(`[READ] Fetching ${typeName} identifier: ${identifier}`);
+
+  const response = await withRetry(
+    () =>
+      client.send(
+        new GetResourceCommand({
+          TypeName: typeName,
+          Identifier: identifier,
+        }),
+      ),
+    `${typeName} read`,
+  );
+
+  if (!response.ResourceDescription?.Properties) {
+    throw new Error(`Failed to get ${typeName} details`);
+  }
+
+  return JSON.parse(response.ResourceDescription.Properties);
+}
+
+/**
+ * Update an AWS resource via CloudControl API.
+ * Reads current state, computes JSON patch (filtering createOnlyProperties),
+ * sends UpdateResourceCommand, polls, then reads the updated resource.
+ */
+export async function updateResource(
+  typeName: string,
+  identifier: string,
+  currentState: Record<string, unknown>,
+  desiredState: Record<string, unknown>,
+  createOnlyProperties?: string[],
+): Promise<Record<string, unknown>> {
+  const client = createClient();
+  const createOnlySet = new Set(createOnlyProperties ?? []);
+
+  console.log(
+    `[UPDATE] Starting update for ${typeName} identifier: ${identifier}`,
+  );
+
+  // Compute JSON patch, filtering out create-only properties
+  const rawPatch = jsonpatch.compare(currentState, desiredState);
+  const patch = rawPatch.filter((op: { path: string }) => {
+    const topLevelProp = op.path.split("/")[1];
+    if (topLevelProp && createOnlySet.has(topLevelProp)) {
+      console.log(`[UPDATE] Skipping create-only property: ${topLevelProp}`);
+      return false;
+    }
+    return true;
+  });
+
+  if (patch.length === 0) {
+    console.log(`[UPDATE] No changes detected, returning current state`);
+    return currentState;
+  }
+
+  console.log(`[UPDATE] Applying ${patch.length} patch operations`);
+
+  const response = await withRetry(
+    () =>
+      client.send(
+        new UpdateResourceCommand({
+          TypeName: typeName,
+          Identifier: identifier,
+          PatchDocument: JSON.stringify(patch),
+        }),
+      ),
+    `${typeName} update`,
+  );
+
+  if (!response.ProgressEvent?.RequestToken) {
+    throw new Error(`${typeName} update failed: no request token returned`);
+  }
+
+  const requestToken = response.ProgressEvent.RequestToken;
+  console.log(`[UPDATE] Got request token: ${requestToken}`);
+
+  const pollResult = await pollOperationStatus(
+    client,
+    requestToken,
+    `${typeName} update`,
+  );
+
+  if (pollResult.status === "FAILED") {
+    throw new Error(
+      `${typeName} update failed: ${pollResult.message || "Unknown error"}`,
+    );
+  }
+  if (pollResult.status === "CANCEL_COMPLETE") {
+    throw new Error(`${typeName} update cancelled: ${pollResult.message}`);
+  }
+
+  const resultIdentifier = pollResult.identifier || identifier;
+  console.log(`[UPDATE] Success, fetching resource ${resultIdentifier}`);
+
+  const getResponse = await withRetry(
+    () =>
+      client.send(
+        new GetResourceCommand({
+          TypeName: typeName,
+          Identifier: resultIdentifier,
+        }),
+      ),
+    `${typeName} update get-resource`,
+  );
+
+  if (!getResponse.ResourceDescription?.Properties) {
+    throw new Error(`Failed to get ${typeName} details after update`);
+  }
+
+  return JSON.parse(getResponse.ResourceDescription.Properties);
+}
+
+/**
+ * Delete an AWS resource via CloudControl API.
+ * Returns { existed: true } on success, { existed: false } if already gone.
+ */
+export async function deleteResource(
+  typeName: string,
+  identifier: string,
+): Promise<{ existed: boolean }> {
+  const client = createClient();
+
+  console.log(
+    `[DELETE] Starting delete for ${typeName} identifier: ${identifier}`,
+  );
+
+  try {
+    const response = await withRetry(
+      () =>
+        client.send(
+          new DeleteResourceCommand({
+            TypeName: typeName,
+            Identifier: identifier,
+          }),
+        ),
+      `${typeName} delete`,
+    );
+
+    if (!response.ProgressEvent?.RequestToken) {
+      throw new Error(`${typeName} deletion failed: no request token returned`);
+    }
+
+    const requestToken = response.ProgressEvent.RequestToken;
+    console.log(`[DELETE] Got request token: ${requestToken}`);
+
+    const pollResult = await pollOperationStatus(
+      client,
+      requestToken,
+      `${typeName} delete`,
+    );
+
+    if (pollResult.status === "FAILED") {
+      if (
+        pollResult.message &&
+        (pollResult.message.includes("was not found") ||
+          pollResult.message.includes("does not exist"))
+      ) {
+        return { existed: false };
+      }
+      throw new Error(
+        `${typeName} deletion failed: ${pollResult.message || "Unknown error"}`,
+      );
+    }
+
+    if (pollResult.status === "CANCEL_COMPLETE") {
+      throw new Error(
+        `${typeName} deletion cancelled: ${pollResult.message}`,
+      );
+    }
+
+    return { existed: true };
+  } catch (error: unknown) {
+    if (isResourceNotFoundError(error)) {
+      return { existed: false };
+    }
+    throw error;
+  }
+}

--- a/model/aws/elasticloadbalancing/extensions/models/load_balancer.ts
+++ b/model/aws/elasticloadbalancing/extensions/models/load_balancer.ts
@@ -1,0 +1,471 @@
+// Auto-generated extension model for @swamp/aws/elasticloadbalancing/load-balancer
+// Do not edit manually. Re-generate with: deno task generate:aws
+
+// deno-lint-ignore-file no-explicit-any
+
+import { z } from "zod";
+import {
+  createResource,
+  deleteResource,
+  isResourceNotFoundError,
+  readResource,
+  updateResource,
+} from "./_lib/aws.ts";
+
+export const AppCookieStickinessPolicySchema = z.object({
+  CookieName: z.string().describe(
+    "The name of the application cookie used for stickiness.",
+  ),
+  PolicyName: z.string().describe(
+    "The mnemonic name for the policy being created. The name must be unique within a set of policies for this load balancer.",
+  ),
+});
+
+export const LBCookieStickinessPolicySchema = z.object({
+  CookieExpirationPeriod: z.string().describe(
+    "The time period, in seconds, after which the cookie should be considered stale. If this parameter is not specified, the stickiness session lasts for the duration of the browser session.",
+  ).optional(),
+  PolicyName: z.string().describe(
+    "The name of the policy. This name must be unique within the set of policies for this load balancer.",
+  ).optional(),
+});
+
+export const ListenersSchema = z.object({
+  PolicyNames: z.array(z.string()).describe(
+    "The names of the policies to associate with the listener.",
+  ).optional(),
+  InstancePort: z.string().describe(
+    "The port on which the instance is listening.",
+  ),
+  LoadBalancerPort: z.string().describe(
+    "The port on which the load balancer is listening. On EC2-VPC, you can specify any port from the range 1-65535. On EC2-Classic, you can specify any port from the following list: 25, 80, 443, 465, 587, 1024-65535.",
+  ),
+  Protocol: z.string().describe(
+    "The load balancer transport protocol to use for routing: HTTP, HTTPS, TCP, or SSL.",
+  ),
+  SSLCertificateId: z.string().describe(
+    "The Amazon Resource Name (ARN) of the server certificate.",
+  ).optional(),
+  InstanceProtocol: z.string().describe(
+    "The protocol to use for routing traffic to instances: HTTP, HTTPS, TCP, or SSL. If the front-end protocol is TCP or SSL, the back-end protocol must be TCP or SSL. If the front-end protocol is HTTP or HTTPS, the back-end protocol must be HTTP or HTTPS. If there is another listener with the same `InstancePort` whose `InstanceProtocol` is secure, (HTTPS or SSL), the listener's `InstanceProtocol` must also be secure. If there is another listener with the same `InstancePort` whose `InstanceProtocol` is HTTP or TCP, the listener's `InstanceProtocol` must be HTTP or TCP.",
+  ).optional(),
+});
+
+export const PolicyItemSchema = z.object({
+  Name: z.string().optional(),
+  Value: z.string().optional(),
+});
+
+export const PoliciesSchema = z.object({
+  Attributes: z.array(PolicyItemSchema).describe("The policy attributes."),
+  PolicyType: z.string().describe("The name of the policy type."),
+  LoadBalancerPorts: z.array(z.string()).describe(
+    "The load balancer ports for the policy. Required only for some policy types.",
+  ).optional(),
+  PolicyName: z.string().describe("The name of the policy."),
+  InstancePorts: z.array(z.string()).describe(
+    "The instance ports for the policy. Required only for some policy types.",
+  ).optional(),
+});
+
+export const TagSchema = z.object({
+  Value: z.string().describe(
+    "The value for the tag. You can specify a value that's 1 to 256 characters in length.",
+  ),
+  Key: z.string().describe(
+    "The key name of the tag. You can specify a value that's 1 to 128 Unicode characters in length and can't be prefixed with `aws:`. You can use any of the following characters: the set of Unicode letters, digits, whitespace, `_`, `.`, `/`, `=`, `+`, and `-`.",
+  ),
+});
+
+const GlobalArgsSchema = z.object({
+  AccessLoggingPolicy: z.object({
+    Enabled: z.boolean().describe(
+      "Specifies whether access logs are enabled for the load balancer.",
+    ),
+    S3BucketName: z.string().describe(
+      "The name of the Amazon S3 bucket where the access logs are stored.",
+    ),
+    EmitInterval: z.number().int().describe(
+      "The interval for publishing the access logs. You can specify an interval of either 5 minutes or 60 minutes. Default: 60 minutes",
+    ).optional(),
+    S3BucketPrefix: z.string().describe(
+      "The logical hierarchy you created for your Amazon S3 bucket, for example `my-bucket-prefix/prod`. If the prefix is not provided, the log is placed at the root level of the bucket.",
+    ).optional(),
+  }).describe(
+    "Information about where and how access logs are stored for the load balancer.",
+  ).optional(),
+  AppCookieStickinessPolicy: z.array(AppCookieStickinessPolicySchema).describe(
+    "Information about a policy for application-controlled session stickiness.",
+  ).optional(),
+  AvailabilityZones: z.array(z.string()).describe(
+    "The Availability Zones for a load balancer in a default VPC. For a load balancer in a nondefault VPC, specify Subnets instead.",
+  ).optional(),
+  ConnectionDrainingPolicy: z.object({
+    Enabled: z.boolean().describe(
+      "Specifies whether connection draining is enabled for the load balancer.",
+    ),
+    Timeout: z.number().int().describe(
+      "The maximum time, in seconds, to keep the existing connections open before deregistering the instances.",
+    ).optional(),
+  }).describe(
+    "If enabled, the load balancer allows existing requests to complete before the load balancer shifts traffic away from a deregistered or unhealthy instance.",
+  ).optional(),
+  ConnectionSettings: z.object({
+    IdleTimeout: z.number().int().describe(
+      "The time, in seconds, that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+    ),
+  }).describe(
+    "If enabled, the load balancer allows the connections to remain idle (no data is sent over the connection) for the specified duration.",
+  ).optional(),
+  CrossZone: z.boolean().describe(
+    "If enabled, the load balancer routes the request traffic evenly across all instances regardless of the Availability Zones.",
+  ).optional(),
+  HealthCheck: z.object({
+    Target: z.string().describe("The instance being checked."),
+    UnhealthyThreshold: z.string().describe(
+      "The number of consecutive health check failures required before moving the instance to the `Unhealthy` state.",
+    ),
+    Timeout: z.string().describe(
+      "The amount of time, in seconds, during which no response means a failed health check. This value must be less than the `Interval` value.",
+    ),
+    HealthyThreshold: z.string().describe(
+      "The number of consecutive health checks successes required before moving the instance to the `Healthy` state.",
+    ),
+    Interval: z.string().describe(
+      "The approximate interval, in seconds, between health checks of an individual instance.",
+    ),
+  }).describe(
+    "The health check settings to use when evaluating the health of your EC2 instances.",
+  ).optional(),
+  Instances: z.array(z.string()).describe(
+    "The IDs of the instances for the load balancer.",
+  ).optional(),
+  LBCookieStickinessPolicy: z.array(LBCookieStickinessPolicySchema).describe(
+    "Information about a policy for duration-based session stickiness.",
+  ).optional(),
+  Listeners: z.array(ListenersSchema).describe(
+    "The Listeners for the load balancer. You can specify at most one listener per port.",
+  ),
+  LoadBalancerName: z.string().describe(
+    "The name of the load balancer. This name must be unique within your set of load balancers for the region.",
+  ).optional(),
+  Policies: z.array(PoliciesSchema).describe(
+    "The policies defined for your Classic Load Balancer. Specify only back-end server policies.",
+  ).optional(),
+  Scheme: z.string().describe(
+    "The type of load balancer. Valid only for load balancers in a VPC.",
+  ).optional(),
+  SecurityGroups: z.array(z.string()).describe(
+    "The security groups for the load balancer. Valid only for load balancers in a VPC.",
+  ).optional(),
+  Subnets: z.array(z.string()).describe(
+    "The IDs of the subnets for the load balancer. You can specify at most one subnet per Availability Zone.",
+  ).optional(),
+  Tags: z.array(TagSchema).describe("The tags associated with a load balancer.")
+    .optional(),
+});
+
+const StateSchema = z.object({
+  AccessLoggingPolicy: z.object({
+    Enabled: z.boolean(),
+    S3BucketName: z.string(),
+    EmitInterval: z.number(),
+    S3BucketPrefix: z.string(),
+  }).optional(),
+  AppCookieStickinessPolicy: z.array(AppCookieStickinessPolicySchema)
+    .optional(),
+  AvailabilityZones: z.array(z.string()).optional(),
+  ConnectionDrainingPolicy: z.object({
+    Enabled: z.boolean(),
+    Timeout: z.number(),
+  }).optional(),
+  ConnectionSettings: z.object({
+    IdleTimeout: z.number(),
+  }).optional(),
+  CrossZone: z.boolean().optional(),
+  HealthCheck: z.object({
+    Target: z.string(),
+    UnhealthyThreshold: z.string(),
+    Timeout: z.string(),
+    HealthyThreshold: z.string(),
+    Interval: z.string(),
+  }).optional(),
+  Instances: z.array(z.string()).optional(),
+  LBCookieStickinessPolicy: z.array(LBCookieStickinessPolicySchema).optional(),
+  Listeners: z.array(ListenersSchema).optional(),
+  LoadBalancerName: z.string(),
+  Policies: z.array(PoliciesSchema).optional(),
+  Scheme: z.string().optional(),
+  SecurityGroups: z.array(z.string()).optional(),
+  Subnets: z.array(z.string()).optional(),
+  Tags: z.array(TagSchema).optional(),
+  CanonicalHostedZoneName: z.string().optional(),
+  CanonicalHostedZoneNameID: z.string().optional(),
+  DNSName: z.string().optional(),
+  SourceSecurityGroup: z.object({
+    GroupName: z.string(),
+    OwnerAlias: z.string(),
+  }).optional(),
+}).passthrough();
+
+type StateData = z.infer<typeof StateSchema>;
+
+const InputsSchema = z.object({
+  AccessLoggingPolicy: z.object({
+    Enabled: z.boolean().describe(
+      "Specifies whether access logs are enabled for the load balancer.",
+    ).optional(),
+    S3BucketName: z.string().describe(
+      "The name of the Amazon S3 bucket where the access logs are stored.",
+    ).optional(),
+    EmitInterval: z.number().int().describe(
+      "The interval for publishing the access logs. You can specify an interval of either 5 minutes or 60 minutes. Default: 60 minutes",
+    ).optional(),
+    S3BucketPrefix: z.string().describe(
+      "The logical hierarchy you created for your Amazon S3 bucket, for example `my-bucket-prefix/prod`. If the prefix is not provided, the log is placed at the root level of the bucket.",
+    ).optional(),
+  }).describe(
+    "Information about where and how access logs are stored for the load balancer.",
+  ).optional(),
+  AppCookieStickinessPolicy: z.array(AppCookieStickinessPolicySchema).describe(
+    "Information about a policy for application-controlled session stickiness.",
+  ).optional(),
+  AvailabilityZones: z.array(z.string()).describe(
+    "The Availability Zones for a load balancer in a default VPC. For a load balancer in a nondefault VPC, specify Subnets instead.",
+  ).optional(),
+  ConnectionDrainingPolicy: z.object({
+    Enabled: z.boolean().describe(
+      "Specifies whether connection draining is enabled for the load balancer.",
+    ).optional(),
+    Timeout: z.number().int().describe(
+      "The maximum time, in seconds, to keep the existing connections open before deregistering the instances.",
+    ).optional(),
+  }).describe(
+    "If enabled, the load balancer allows existing requests to complete before the load balancer shifts traffic away from a deregistered or unhealthy instance.",
+  ).optional(),
+  ConnectionSettings: z.object({
+    IdleTimeout: z.number().int().describe(
+      "The time, in seconds, that the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.",
+    ).optional(),
+  }).describe(
+    "If enabled, the load balancer allows the connections to remain idle (no data is sent over the connection) for the specified duration.",
+  ).optional(),
+  CrossZone: z.boolean().describe(
+    "If enabled, the load balancer routes the request traffic evenly across all instances regardless of the Availability Zones.",
+  ).optional(),
+  HealthCheck: z.object({
+    Target: z.string().describe("The instance being checked.").optional(),
+    UnhealthyThreshold: z.string().describe(
+      "The number of consecutive health check failures required before moving the instance to the `Unhealthy` state.",
+    ).optional(),
+    Timeout: z.string().describe(
+      "The amount of time, in seconds, during which no response means a failed health check. This value must be less than the `Interval` value.",
+    ).optional(),
+    HealthyThreshold: z.string().describe(
+      "The number of consecutive health checks successes required before moving the instance to the `Healthy` state.",
+    ).optional(),
+    Interval: z.string().describe(
+      "The approximate interval, in seconds, between health checks of an individual instance.",
+    ).optional(),
+  }).describe(
+    "The health check settings to use when evaluating the health of your EC2 instances.",
+  ).optional(),
+  Instances: z.array(z.string()).describe(
+    "The IDs of the instances for the load balancer.",
+  ).optional(),
+  LBCookieStickinessPolicy: z.array(LBCookieStickinessPolicySchema).describe(
+    "Information about a policy for duration-based session stickiness.",
+  ).optional(),
+  Listeners: z.array(ListenersSchema).describe(
+    "The Listeners for the load balancer. You can specify at most one listener per port.",
+  ).optional(),
+  LoadBalancerName: z.string().describe(
+    "The name of the load balancer. This name must be unique within your set of load balancers for the region.",
+  ).optional(),
+  Policies: z.array(PoliciesSchema).describe(
+    "The policies defined for your Classic Load Balancer. Specify only back-end server policies.",
+  ).optional(),
+  Scheme: z.string().describe(
+    "The type of load balancer. Valid only for load balancers in a VPC.",
+  ).optional(),
+  SecurityGroups: z.array(z.string()).describe(
+    "The security groups for the load balancer. Valid only for load balancers in a VPC.",
+  ).optional(),
+  Subnets: z.array(z.string()).describe(
+    "The IDs of the subnets for the load balancer. You can specify at most one subnet per Availability Zone.",
+  ).optional(),
+  Tags: z.array(TagSchema).describe("The tags associated with a load balancer.")
+    .optional(),
+});
+
+export const model = {
+  type: "@swamp/aws/elasticloadbalancing/load-balancer",
+  version: "2026.04.03.1",
+  globalArguments: GlobalArgsSchema,
+  inputsSchema: InputsSchema,
+  resources: {
+    state: {
+      description: "ElasticLoadBalancing LoadBalancer resource state",
+      schema: StateSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    create: {
+      description: "Create a ElasticLoadBalancing LoadBalancer",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const desiredState: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(g)) {
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await createResource(
+          "AWS::ElasticLoadBalancing::LoadBalancer",
+          desiredState,
+        ) as StateData;
+        const instanceName =
+          (result.LoadBalancerName ?? g.LoadBalancerName)?.toString() ??
+            "current";
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    get: {
+      description: "Get a ElasticLoadBalancing LoadBalancer",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the ElasticLoadBalancing LoadBalancer",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const result = await readResource(
+          "AWS::ElasticLoadBalancing::LoadBalancer",
+          args.identifier,
+        ) as StateData;
+        const instanceName =
+          (result.LoadBalancerName ?? context.globalArgs.LoadBalancerName)
+            ?.toString() ?? args.identifier;
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    update: {
+      description: "Update a ElasticLoadBalancing LoadBalancer",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = g.LoadBalancerName?.toString() ?? "current";
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const identifier = existing.LoadBalancerName?.toString();
+        if (!identifier) {
+          throw new Error("No identifier found in existing state");
+        }
+        const currentState = await readResource(
+          "AWS::ElasticLoadBalancing::LoadBalancer",
+          identifier,
+        ) as StateData;
+        const desiredState: Record<string, unknown> = { ...currentState };
+        for (const [key, value] of Object.entries(g)) {
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await updateResource(
+          "AWS::ElasticLoadBalancing::LoadBalancer",
+          identifier,
+          currentState,
+          desiredState,
+          ["LoadBalancerName", "Scheme"],
+        );
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    delete: {
+      description: "Delete a ElasticLoadBalancing LoadBalancer",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the ElasticLoadBalancing LoadBalancer",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const { existed } = await deleteResource(
+          "AWS::ElasticLoadBalancing::LoadBalancer",
+          args.identifier,
+        );
+        const instanceName = context.globalArgs.LoadBalancerName?.toString() ??
+          args.identifier;
+        const handle = await context.writeResource("state", instanceName, {
+          identifier: args.identifier,
+          existed,
+          status: existed ? "deleted" : "not_found",
+          deletedAt: new Date().toISOString(),
+        });
+        return { dataHandles: [handle] };
+      },
+    },
+    sync: {
+      description: "Sync ElasticLoadBalancing LoadBalancer state from AWS",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = g.LoadBalancerName?.toString() ?? "current";
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const identifier = existing.LoadBalancerName?.toString();
+        if (!identifier) {
+          throw new Error("No identifier found in existing state");
+        }
+        try {
+          const result = await readResource(
+            "AWS::ElasticLoadBalancing::LoadBalancer",
+            identifier,
+          ) as StateData;
+          const handle = await context.writeResource(
+            "state",
+            instanceName,
+            result,
+          );
+          return { dataHandles: [handle] };
+        } catch (error: unknown) {
+          if (isResourceNotFoundError(error)) {
+            const handle = await context.writeResource("state", instanceName, {
+              identifier,
+              status: "not_found",
+              syncedAt: new Date().toISOString(),
+            });
+            return { dataHandles: [handle] };
+          }
+          throw error;
+        }
+      },
+    },
+  },
+};

--- a/model/aws/elasticloadbalancing/manifest.yaml
+++ b/model/aws/elasticloadbalancing/manifest.yaml
@@ -1,0 +1,17 @@
+# Auto-generated manifest. Re-generate with the appropriate deno task.
+manifestVersion: 1
+name: "@swamp/aws/elasticloadbalancing"
+version: "2026.04.03.1"
+description: "AWS ELASTICLOADBALANCING infrastructure models"
+labels:
+  - aws
+  - elasticloadbalancing
+  - cloud
+  - infrastructure
+releaseNotes: |
+  - Added: load_balancer
+models:
+  - load_balancer.ts
+additionalFiles:
+  - LICENSE.txt
+  - README.md

--- a/model/aws/novaact/LICENSE.txt
+++ b/model/aws/novaact/LICENSE.txt
@@ -1,0 +1,14 @@
+Copyright (C) 2026 System Initiative, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/model/aws/novaact/README.md
+++ b/model/aws/novaact/README.md
@@ -1,0 +1,65 @@
+# @swamp/aws/novaact
+
+Auto-generated [swamp](https://github.com/systeminit/swamp) extension models for
+AWS NOVAACT resources.
+
+Each model represents a single AWS resource (e.g., a VPC, an S3 bucket, an IAM
+role). Models have **domain properties** that you configure (the desired state)
+and **resource properties** that reflect the live state in AWS. Available
+methods:
+
+- **create** — provision the resource in AWS using the configured properties
+- **get** — fetch the current state of a specific resource by identifier
+- **update** — apply property changes to an existing resource
+- **delete** — remove the resource from AWS
+- **sync** — refresh all resource properties from AWS
+
+Use `swamp model type describe @swamp/aws/novaact/workflow_definition` to see
+the full list of configurable properties and available methods for this model.
+
+## Authentication
+
+These models use the AWS SDK v3 default credential chain. Credentials are
+resolved in the following order:
+
+1. **Environment variables** — `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` +
+   optional `AWS_SESSION_TOKEN`
+2. **SSO credentials** — `aws sso login`
+3. **Shared credentials file** — `~/.aws/credentials`
+4. **Shared config file** — `~/.aws/config` (profiles, `credential_process`,
+   SSO)
+5. **ECS container credentials** — task IAM role
+6. **EC2 instance metadata** — instance profile
+
+### Region
+
+The `AWS_REGION` environment variable controls which region resources are
+created and managed in. Defaults to `us-east-1` if not set.
+
+### Setup
+
+```bash
+export AWS_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=wJal...
+```
+
+## Usage
+
+```bash
+# Create a new workflow_definition model
+swamp model create @swamp/aws/novaact/workflow_definition my-workflow_definition
+
+# Edit the model to configure its properties
+swamp model edit my-workflow_definition
+
+# Create the resource in AWS
+swamp model method run my-workflow_definition create
+
+# Sync current state from AWS
+swamp model method run my-workflow_definition sync
+```
+
+## License
+
+AGPLv3 — see [LICENSE.txt](./LICENSE.txt).

--- a/model/aws/novaact/deno.json
+++ b/model/aws/novaact/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "zod": "npm:zod@4.3.6",
+    "@aws-sdk/client-cloudcontrol": "npm:@aws-sdk/client-cloudcontrol@3.1021.0",
+    "fast-json-patch": "npm:fast-json-patch@3.1.1"
+  }
+}

--- a/model/aws/novaact/deno.lock
+++ b/model/aws/novaact/deno.lock
@@ -1,0 +1,776 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@aws-sdk/client-cloudcontrol@3.1021.0": "3.1021.0",
+    "npm:fast-json-patch@3.1.1": "3.1.1",
+    "npm:zod@4.3.6": "4.3.6"
+  },
+  "npm": {
+    "@aws-crypto/sha256-browser@5.2.0": {
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dependencies": [
+        "@aws-crypto/sha256-js",
+        "@aws-crypto/supports-web-crypto",
+        "@aws-crypto/util",
+        "@aws-sdk/types",
+        "@aws-sdk/util-locate-window",
+        "@smithy/util-utf8@2.3.0",
+        "tslib"
+      ]
+    },
+    "@aws-crypto/sha256-js@5.2.0": {
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dependencies": [
+        "@aws-crypto/util",
+        "@aws-sdk/types",
+        "tslib"
+      ]
+    },
+    "@aws-crypto/supports-web-crypto@5.2.0": {
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@aws-crypto/util@5.2.0": {
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/util-utf8@2.3.0",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/client-cloudcontrol@3.1021.0": {
+      "integrity": "sha512-VbrIC3iT4OveHdkjYdMdwGk60YNOmN0OsL1QEuEjOwUmjq1aYRzgtjNb9fGR9a8CWhGA7yjqWDaUeNJ+wUGzMw==",
+      "dependencies": [
+        "@aws-crypto/sha256-browser",
+        "@aws-crypto/sha256-js",
+        "@aws-sdk/core",
+        "@aws-sdk/credential-provider-node",
+        "@aws-sdk/middleware-host-header",
+        "@aws-sdk/middleware-logger",
+        "@aws-sdk/middleware-recursion-detection",
+        "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/region-config-resolver",
+        "@aws-sdk/types",
+        "@aws-sdk/util-endpoints",
+        "@aws-sdk/util-user-agent-browser",
+        "@aws-sdk/util-user-agent-node",
+        "@smithy/config-resolver",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/hash-node",
+        "@smithy/invalid-dependency",
+        "@smithy/middleware-content-length",
+        "@smithy/middleware-endpoint",
+        "@smithy/middleware-retry",
+        "@smithy/middleware-serde",
+        "@smithy/middleware-stack",
+        "@smithy/node-config-provider",
+        "@smithy/node-http-handler",
+        "@smithy/protocol-http",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-base64",
+        "@smithy/util-body-length-browser",
+        "@smithy/util-body-length-node",
+        "@smithy/util-defaults-mode-browser",
+        "@smithy/util-defaults-mode-node",
+        "@smithy/util-endpoints",
+        "@smithy/util-middleware",
+        "@smithy/util-retry",
+        "@smithy/util-utf8@4.2.2",
+        "@smithy/util-waiter",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/core@3.973.26": {
+      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@aws-sdk/xml-builder",
+        "@smithy/core",
+        "@smithy/node-config-provider",
+        "@smithy/property-provider",
+        "@smithy/protocol-http",
+        "@smithy/signature-v4",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/util-base64",
+        "@smithy/util-middleware",
+        "@smithy/util-utf8@4.2.2",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-env@3.972.24": {
+      "integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-http@3.972.26": {
+      "integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/fetch-http-handler",
+        "@smithy/node-http-handler",
+        "@smithy/property-provider",
+        "@smithy/protocol-http",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/util-stream",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-ini@3.972.28": {
+      "integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/credential-provider-env",
+        "@aws-sdk/credential-provider-http",
+        "@aws-sdk/credential-provider-login",
+        "@aws-sdk/credential-provider-process",
+        "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-web-identity",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/credential-provider-imds",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-login@3.972.28": {
+      "integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/protocol-http",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-node@3.972.29": {
+      "integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
+      "dependencies": [
+        "@aws-sdk/credential-provider-env",
+        "@aws-sdk/credential-provider-http",
+        "@aws-sdk/credential-provider-ini",
+        "@aws-sdk/credential-provider-process",
+        "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-web-identity",
+        "@aws-sdk/types",
+        "@smithy/credential-provider-imds",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-process@3.972.24": {
+      "integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-sso@3.972.28": {
+      "integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/token-providers",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/credential-provider-web-identity@3.972.28": {
+      "integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-host-header@3.972.8": {
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-logger@3.972.8": {
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-recursion-detection@3.972.9": {
+      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@aws/lambda-invoke-store",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/middleware-user-agent@3.972.28": {
+      "integrity": "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/types",
+        "@aws-sdk/util-endpoints",
+        "@smithy/core",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "@smithy/util-retry",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/nested-clients@3.996.18": {
+      "integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
+      "dependencies": [
+        "@aws-crypto/sha256-browser",
+        "@aws-crypto/sha256-js",
+        "@aws-sdk/core",
+        "@aws-sdk/middleware-host-header",
+        "@aws-sdk/middleware-logger",
+        "@aws-sdk/middleware-recursion-detection",
+        "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/region-config-resolver",
+        "@aws-sdk/types",
+        "@aws-sdk/util-endpoints",
+        "@aws-sdk/util-user-agent-browser",
+        "@aws-sdk/util-user-agent-node",
+        "@smithy/config-resolver",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/hash-node",
+        "@smithy/invalid-dependency",
+        "@smithy/middleware-content-length",
+        "@smithy/middleware-endpoint",
+        "@smithy/middleware-retry",
+        "@smithy/middleware-serde",
+        "@smithy/middleware-stack",
+        "@smithy/node-config-provider",
+        "@smithy/node-http-handler",
+        "@smithy/protocol-http",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-base64",
+        "@smithy/util-body-length-browser",
+        "@smithy/util-body-length-node",
+        "@smithy/util-defaults-mode-browser",
+        "@smithy/util-defaults-mode-node",
+        "@smithy/util-endpoints",
+        "@smithy/util-middleware",
+        "@smithy/util-retry",
+        "@smithy/util-utf8@4.2.2",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/region-config-resolver@3.972.10": {
+      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/config-resolver",
+        "@smithy/node-config-provider",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/token-providers@3.1021.0": {
+      "integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
+      "dependencies": [
+        "@aws-sdk/core",
+        "@aws-sdk/nested-clients",
+        "@aws-sdk/types",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/types@3.973.6": {
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/util-endpoints@3.996.5": {
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-endpoints",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/util-locate-window@3.965.5": {
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@aws-sdk/util-user-agent-browser@3.972.8": {
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "dependencies": [
+        "@aws-sdk/types",
+        "@smithy/types",
+        "bowser",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/util-user-agent-node@3.973.14": {
+      "integrity": "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==",
+      "dependencies": [
+        "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/types",
+        "@smithy/node-config-provider",
+        "@smithy/types",
+        "@smithy/util-config-provider",
+        "tslib"
+      ]
+    },
+    "@aws-sdk/xml-builder@3.972.16": {
+      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "dependencies": [
+        "@smithy/types",
+        "fast-xml-parser",
+        "tslib"
+      ]
+    },
+    "@aws/lambda-invoke-store@0.2.4": {
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="
+    },
+    "@smithy/config-resolver@4.4.13": {
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+      "dependencies": [
+        "@smithy/node-config-provider",
+        "@smithy/types",
+        "@smithy/util-config-provider",
+        "@smithy/util-endpoints",
+        "@smithy/util-middleware",
+        "tslib"
+      ]
+    },
+    "@smithy/core@3.23.13": {
+      "integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
+      "dependencies": [
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-base64",
+        "@smithy/util-body-length-browser",
+        "@smithy/util-middleware",
+        "@smithy/util-stream",
+        "@smithy/util-utf8@4.2.2",
+        "@smithy/uuid",
+        "tslib"
+      ]
+    },
+    "@smithy/credential-provider-imds@4.2.12": {
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "dependencies": [
+        "@smithy/node-config-provider",
+        "@smithy/property-provider",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "tslib"
+      ]
+    },
+    "@smithy/fetch-http-handler@5.3.15": {
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "dependencies": [
+        "@smithy/protocol-http",
+        "@smithy/querystring-builder",
+        "@smithy/types",
+        "@smithy/util-base64",
+        "tslib"
+      ]
+    },
+    "@smithy/hash-node@4.2.12": {
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+      "dependencies": [
+        "@smithy/types",
+        "@smithy/util-buffer-from@4.2.2",
+        "@smithy/util-utf8@4.2.2",
+        "tslib"
+      ]
+    },
+    "@smithy/invalid-dependency@4.2.12": {
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/is-array-buffer@2.2.0": {
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/is-array-buffer@4.2.2": {
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-content-length@4.2.12": {
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+      "dependencies": [
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-endpoint@4.4.28": {
+      "integrity": "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/middleware-serde",
+        "@smithy/node-config-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-middleware",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-retry@4.4.46": {
+      "integrity": "sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==",
+      "dependencies": [
+        "@smithy/node-config-provider",
+        "@smithy/protocol-http",
+        "@smithy/service-error-classification",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/util-middleware",
+        "@smithy/util-retry",
+        "@smithy/uuid",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-serde@4.2.16": {
+      "integrity": "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/middleware-stack@4.2.12": {
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/node-config-provider@4.3.12": {
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+      "dependencies": [
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/node-http-handler@4.5.1": {
+      "integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
+      "dependencies": [
+        "@smithy/protocol-http",
+        "@smithy/querystring-builder",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/property-provider@4.2.12": {
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/protocol-http@5.3.12": {
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/querystring-builder@4.2.12": {
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+      "dependencies": [
+        "@smithy/types",
+        "@smithy/util-uri-escape",
+        "tslib"
+      ]
+    },
+    "@smithy/querystring-parser@4.2.12": {
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/service-error-classification@4.2.12": {
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+      "dependencies": [
+        "@smithy/types"
+      ]
+    },
+    "@smithy/shared-ini-file-loader@4.4.7": {
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/signature-v4@5.3.12": {
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "dependencies": [
+        "@smithy/is-array-buffer@4.2.2",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "@smithy/util-hex-encoding",
+        "@smithy/util-middleware",
+        "@smithy/util-uri-escape",
+        "@smithy/util-utf8@4.2.2",
+        "tslib"
+      ]
+    },
+    "@smithy/smithy-client@4.12.8": {
+      "integrity": "sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==",
+      "dependencies": [
+        "@smithy/core",
+        "@smithy/middleware-endpoint",
+        "@smithy/middleware-stack",
+        "@smithy/protocol-http",
+        "@smithy/types",
+        "@smithy/util-stream",
+        "tslib"
+      ]
+    },
+    "@smithy/types@4.13.1": {
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/url-parser@4.2.12": {
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+      "dependencies": [
+        "@smithy/querystring-parser",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-base64@4.3.2": {
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "dependencies": [
+        "@smithy/util-buffer-from@4.2.2",
+        "@smithy/util-utf8@4.2.2",
+        "tslib"
+      ]
+    },
+    "@smithy/util-body-length-browser@4.2.2": {
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-body-length-node@4.2.3": {
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-buffer-from@2.2.0": {
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": [
+        "@smithy/is-array-buffer@2.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/util-buffer-from@4.2.2": {
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "dependencies": [
+        "@smithy/is-array-buffer@4.2.2",
+        "tslib"
+      ]
+    },
+    "@smithy/util-config-provider@4.2.2": {
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-defaults-mode-browser@4.3.44": {
+      "integrity": "sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==",
+      "dependencies": [
+        "@smithy/property-provider",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-defaults-mode-node@4.2.48": {
+      "integrity": "sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==",
+      "dependencies": [
+        "@smithy/config-resolver",
+        "@smithy/credential-provider-imds",
+        "@smithy/node-config-provider",
+        "@smithy/property-provider",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-endpoints@3.3.3": {
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+      "dependencies": [
+        "@smithy/node-config-provider",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-hex-encoding@4.2.2": {
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-middleware@4.2.12": {
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-retry@4.2.13": {
+      "integrity": "sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==",
+      "dependencies": [
+        "@smithy/service-error-classification",
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/util-stream@4.5.21": {
+      "integrity": "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==",
+      "dependencies": [
+        "@smithy/fetch-http-handler",
+        "@smithy/node-http-handler",
+        "@smithy/types",
+        "@smithy/util-base64",
+        "@smithy/util-buffer-from@4.2.2",
+        "@smithy/util-hex-encoding",
+        "@smithy/util-utf8@4.2.2",
+        "tslib"
+      ]
+    },
+    "@smithy/util-uri-escape@4.2.2": {
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@smithy/util-utf8@2.3.0": {
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": [
+        "@smithy/util-buffer-from@2.2.0",
+        "tslib"
+      ]
+    },
+    "@smithy/util-utf8@4.2.2": {
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "dependencies": [
+        "@smithy/util-buffer-from@4.2.2",
+        "tslib"
+      ]
+    },
+    "@smithy/util-waiter@4.2.14": {
+      "integrity": "sha512-2zqq5o/oizvMaFUlNiTyZ7dbgYv1a893aGut2uaxtbzTx/VYYnRxWzDHuD/ftgcw94ffenua+ZNLrbqwUYE+Bg==",
+      "dependencies": [
+        "@smithy/types",
+        "tslib"
+      ]
+    },
+    "@smithy/uuid@1.1.2": {
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "bowser@2.14.1": {
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
+    },
+    "fast-json-patch@3.1.1": {
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
+    },
+    "fast-xml-builder@1.1.4": {
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "dependencies": [
+        "path-expression-matcher"
+      ]
+    },
+    "fast-xml-parser@5.5.8": {
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "dependencies": [
+        "fast-xml-builder",
+        "path-expression-matcher",
+        "strnum"
+      ],
+      "bin": true
+    },
+    "path-expression-matcher@1.2.1": {
+      "integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw=="
+    },
+    "strnum@2.2.2": {
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "zod@4.3.6": {
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@aws-sdk/client-cloudcontrol@3.1021.0",
+      "npm:fast-json-patch@3.1.1",
+      "npm:zod@4.3.6"
+    ]
+  }
+}

--- a/model/aws/novaact/extensions/models/_lib/aws.ts
+++ b/model/aws/novaact/extensions/models/_lib/aws.ts
@@ -1,0 +1,395 @@
+// Auto-generated shared helper for AWS CloudControl extension models.
+// Do not edit manually. Re-generate with: deno task generate:aws
+
+import {
+  CloudControlClient,
+  CreateResourceCommand,
+  DeleteResourceCommand,
+  GetResourceCommand,
+  GetResourceRequestStatusCommand,
+  UpdateResourceCommand,
+} from "@aws-sdk/client-cloudcontrol";
+import jsonpatch from "fast-json-patch";
+
+function createClient(): CloudControlClient {
+  return new CloudControlClient({
+    region: Deno.env.get("AWS_REGION") || "us-east-1",
+  });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isThrottlingError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  const name = error instanceof Error ? error.name : "";
+  return (
+    msg.includes("Throttling") ||
+    msg.includes("TooManyRequests") ||
+    msg.includes("RequestLimitExceeded") ||
+    name === "ThrottlingException"
+  );
+}
+
+export function isResourceNotFoundError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  const name = error instanceof Error ? error.name : "";
+  return (
+    msg.includes("was not found") ||
+    msg.includes("does not exist") ||
+    name === "ResourceNotFoundException"
+  );
+}
+
+async function withRetry<T>(
+  operation: () => Promise<T>,
+  operationName: string,
+  maxAttempts = 20,
+): Promise<T> {
+  const baseDelay = 1000;
+  const maxDelay = 90000;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (isThrottlingError(error) && attempt < maxAttempts - 1) {
+        const exponentialDelay = Math.min(
+          baseDelay * Math.pow(2, attempt),
+          maxDelay,
+        );
+        const jitter = Math.random() * 0.3 * exponentialDelay;
+        console.log(
+          `[${operationName}] Throttled on attempt ${attempt + 1}, waiting ${
+            Math.round(exponentialDelay + jitter)
+          }ms`,
+        );
+        await delay(exponentialDelay + jitter);
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error(`${operationName} failed after ${maxAttempts} attempts`);
+}
+
+async function pollOperationStatus(
+  client: CloudControlClient,
+  requestToken: string,
+  operationName: string,
+): Promise<{ status: string; identifier?: string; message?: string }> {
+  const baseDelay = 1000;
+  const maxDelay = 90000;
+
+  for (let attempt = 0; attempt < 60; attempt++) {
+    const response = await withRetry(
+      () =>
+        client.send(
+          new GetResourceRequestStatusCommand({
+            RequestToken: requestToken,
+          }),
+        ),
+      `${operationName} status poll`,
+    );
+
+    const status = response.ProgressEvent?.OperationStatus;
+    if (status === "SUCCESS") {
+      return {
+        status: "SUCCESS",
+        identifier: response.ProgressEvent?.Identifier,
+      };
+    }
+    if (status === "FAILED") {
+      return {
+        status: "FAILED",
+        message: response.ProgressEvent?.StatusMessage ||
+          response.ProgressEvent?.ErrorCode,
+      };
+    }
+    if (status === "CANCEL_COMPLETE") {
+      return {
+        status: "CANCEL_COMPLETE",
+        message: "Operation cancelled by API or AWS",
+      };
+    }
+
+    const exponentialDelay = Math.min(
+      baseDelay * Math.pow(2, attempt),
+      maxDelay,
+    );
+    const jitter = Math.random() * 0.3 * exponentialDelay;
+    console.log(
+      `[${operationName}] IN_PROGRESS, waiting ${
+        Math.round(exponentialDelay + jitter)
+      }ms (poll ${attempt + 1})`,
+    );
+    await delay(exponentialDelay + jitter);
+  }
+
+  throw new Error(`${operationName} timed out after polling`);
+}
+
+/**
+ * Create an AWS resource via CloudControl API.
+ * Sends CreateResourceCommand, polls until complete, then reads the resource.
+ * Returns the resource properties.
+ */
+export async function createResource(
+  typeName: string,
+  desiredState: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const client = createClient();
+
+  console.log(`[CREATE] Starting create for ${typeName}`);
+
+  const response = await withRetry(
+    () =>
+      client.send(
+        new CreateResourceCommand({
+          TypeName: typeName,
+          DesiredState: JSON.stringify(desiredState),
+        }),
+      ),
+    `${typeName} create`,
+  );
+
+  if (!response.ProgressEvent?.RequestToken) {
+    throw new Error(`${typeName} creation failed: no request token returned`);
+  }
+
+  const requestToken = response.ProgressEvent.RequestToken;
+  console.log(`[CREATE] Got request token: ${requestToken}`);
+
+  const pollResult = await pollOperationStatus(
+    client,
+    requestToken,
+    `${typeName} create`,
+  );
+
+  if (pollResult.status === "FAILED") {
+    throw new Error(
+      `${typeName} creation failed: ${pollResult.message || "Unknown error"}`,
+    );
+  }
+  if (pollResult.status === "CANCEL_COMPLETE") {
+    throw new Error(
+      `${typeName} creation cancelled: ${pollResult.message}`,
+    );
+  }
+
+  const identifier = pollResult.identifier;
+  if (!identifier) {
+    throw new Error(
+      `${typeName} creation succeeded but no identifier returned`,
+    );
+  }
+
+  console.log(`[CREATE] Success, fetching resource ${identifier}`);
+
+  const getResponse = await withRetry(
+    () =>
+      client.send(
+        new GetResourceCommand({
+          TypeName: typeName,
+          Identifier: identifier,
+        }),
+      ),
+    `${typeName} create get-resource`,
+  );
+
+  if (!getResponse.ResourceDescription?.Properties) {
+    throw new Error(`Failed to get ${typeName} details after creation`);
+  }
+
+  return JSON.parse(getResponse.ResourceDescription.Properties);
+}
+
+/**
+ * Read an AWS resource via CloudControl API.
+ * Returns the resource properties, or throws if not found.
+ */
+export async function readResource(
+  typeName: string,
+  identifier: string,
+): Promise<Record<string, unknown>> {
+  const client = createClient();
+
+  console.log(`[READ] Fetching ${typeName} identifier: ${identifier}`);
+
+  const response = await withRetry(
+    () =>
+      client.send(
+        new GetResourceCommand({
+          TypeName: typeName,
+          Identifier: identifier,
+        }),
+      ),
+    `${typeName} read`,
+  );
+
+  if (!response.ResourceDescription?.Properties) {
+    throw new Error(`Failed to get ${typeName} details`);
+  }
+
+  return JSON.parse(response.ResourceDescription.Properties);
+}
+
+/**
+ * Update an AWS resource via CloudControl API.
+ * Reads current state, computes JSON patch (filtering createOnlyProperties),
+ * sends UpdateResourceCommand, polls, then reads the updated resource.
+ */
+export async function updateResource(
+  typeName: string,
+  identifier: string,
+  currentState: Record<string, unknown>,
+  desiredState: Record<string, unknown>,
+  createOnlyProperties?: string[],
+): Promise<Record<string, unknown>> {
+  const client = createClient();
+  const createOnlySet = new Set(createOnlyProperties ?? []);
+
+  console.log(
+    `[UPDATE] Starting update for ${typeName} identifier: ${identifier}`,
+  );
+
+  // Compute JSON patch, filtering out create-only properties
+  const rawPatch = jsonpatch.compare(currentState, desiredState);
+  const patch = rawPatch.filter((op: { path: string }) => {
+    const topLevelProp = op.path.split("/")[1];
+    if (topLevelProp && createOnlySet.has(topLevelProp)) {
+      console.log(`[UPDATE] Skipping create-only property: ${topLevelProp}`);
+      return false;
+    }
+    return true;
+  });
+
+  if (patch.length === 0) {
+    console.log(`[UPDATE] No changes detected, returning current state`);
+    return currentState;
+  }
+
+  console.log(`[UPDATE] Applying ${patch.length} patch operations`);
+
+  const response = await withRetry(
+    () =>
+      client.send(
+        new UpdateResourceCommand({
+          TypeName: typeName,
+          Identifier: identifier,
+          PatchDocument: JSON.stringify(patch),
+        }),
+      ),
+    `${typeName} update`,
+  );
+
+  if (!response.ProgressEvent?.RequestToken) {
+    throw new Error(`${typeName} update failed: no request token returned`);
+  }
+
+  const requestToken = response.ProgressEvent.RequestToken;
+  console.log(`[UPDATE] Got request token: ${requestToken}`);
+
+  const pollResult = await pollOperationStatus(
+    client,
+    requestToken,
+    `${typeName} update`,
+  );
+
+  if (pollResult.status === "FAILED") {
+    throw new Error(
+      `${typeName} update failed: ${pollResult.message || "Unknown error"}`,
+    );
+  }
+  if (pollResult.status === "CANCEL_COMPLETE") {
+    throw new Error(`${typeName} update cancelled: ${pollResult.message}`);
+  }
+
+  const resultIdentifier = pollResult.identifier || identifier;
+  console.log(`[UPDATE] Success, fetching resource ${resultIdentifier}`);
+
+  const getResponse = await withRetry(
+    () =>
+      client.send(
+        new GetResourceCommand({
+          TypeName: typeName,
+          Identifier: resultIdentifier,
+        }),
+      ),
+    `${typeName} update get-resource`,
+  );
+
+  if (!getResponse.ResourceDescription?.Properties) {
+    throw new Error(`Failed to get ${typeName} details after update`);
+  }
+
+  return JSON.parse(getResponse.ResourceDescription.Properties);
+}
+
+/**
+ * Delete an AWS resource via CloudControl API.
+ * Returns { existed: true } on success, { existed: false } if already gone.
+ */
+export async function deleteResource(
+  typeName: string,
+  identifier: string,
+): Promise<{ existed: boolean }> {
+  const client = createClient();
+
+  console.log(
+    `[DELETE] Starting delete for ${typeName} identifier: ${identifier}`,
+  );
+
+  try {
+    const response = await withRetry(
+      () =>
+        client.send(
+          new DeleteResourceCommand({
+            TypeName: typeName,
+            Identifier: identifier,
+          }),
+        ),
+      `${typeName} delete`,
+    );
+
+    if (!response.ProgressEvent?.RequestToken) {
+      throw new Error(`${typeName} deletion failed: no request token returned`);
+    }
+
+    const requestToken = response.ProgressEvent.RequestToken;
+    console.log(`[DELETE] Got request token: ${requestToken}`);
+
+    const pollResult = await pollOperationStatus(
+      client,
+      requestToken,
+      `${typeName} delete`,
+    );
+
+    if (pollResult.status === "FAILED") {
+      if (
+        pollResult.message &&
+        (pollResult.message.includes("was not found") ||
+          pollResult.message.includes("does not exist"))
+      ) {
+        return { existed: false };
+      }
+      throw new Error(
+        `${typeName} deletion failed: ${pollResult.message || "Unknown error"}`,
+      );
+    }
+
+    if (pollResult.status === "CANCEL_COMPLETE") {
+      throw new Error(
+        `${typeName} deletion cancelled: ${pollResult.message}`,
+      );
+    }
+
+    return { existed: true };
+  } catch (error: unknown) {
+    if (isResourceNotFoundError(error)) {
+      return { existed: false };
+    }
+    throw error;
+  }
+}

--- a/model/aws/novaact/extensions/models/workflow_definition.ts
+++ b/model/aws/novaact/extensions/models/workflow_definition.ts
@@ -1,0 +1,203 @@
+// Auto-generated extension model for @swamp/aws/novaact/workflow-definition
+// Do not edit manually. Re-generate with: deno task generate:aws
+
+// deno-lint-ignore-file no-explicit-any
+
+import { z } from "zod";
+import {
+  createResource,
+  deleteResource,
+  isResourceNotFoundError,
+  readResource,
+} from "./_lib/aws.ts";
+
+const GlobalArgsSchema = z.object({
+  name: z.string().describe(
+    "Instance name for this resource (used as the unique identifier in the factory pattern)",
+  ),
+  Description: z.string().min(1).max(4000).describe(
+    "An optional description of the workflow definition's purpose and functionality.",
+  ).optional(),
+  ExportConfig: z.object({
+    S3BucketName: z.string().min(3).max(63).regex(
+      new RegExp("^[a-z0-9][a-z0-9.-]*[a-z0-9]$"),
+    ).describe("The name of the Amazon S3 bucket for exporting workflow data."),
+    S3KeyPrefix: z.string().min(1).max(100).regex(
+      new RegExp("^[a-zA-Z0-9!\\-_.*'()]+(?:/[a-zA-Z0-9!\\-_.*'()]+)*$"),
+    ).describe(
+      "An optional prefix for Amazon S3 object keys to organize exported data.",
+    ).optional(),
+  }).describe(
+    "Configuration settings for exporting workflow execution data and logs to Amazon S3.",
+  ).optional(),
+  Name: z.string().min(1).max(40).regex(new RegExp("^[a-zA-Z0-9_-]{1,40}$"))
+    .describe(
+      "The name of the workflow definition. Must be unique within your account and region.",
+    ),
+});
+
+const StateSchema = z.object({
+  Arn: z.string(),
+  CreatedAt: z.string().optional(),
+  Description: z.string().optional(),
+  ExportConfig: z.object({
+    S3BucketName: z.string(),
+    S3KeyPrefix: z.string(),
+  }).optional(),
+  Name: z.string().optional(),
+  Status: z.string().optional(),
+}).passthrough();
+
+type StateData = z.infer<typeof StateSchema>;
+
+const InputsSchema = z.object({
+  name: z.string().optional(),
+  Description: z.string().min(1).max(4000).describe(
+    "An optional description of the workflow definition's purpose and functionality.",
+  ).optional(),
+  ExportConfig: z.object({
+    S3BucketName: z.string().min(3).max(63).regex(
+      new RegExp("^[a-z0-9][a-z0-9.-]*[a-z0-9]$"),
+    ).describe("The name of the Amazon S3 bucket for exporting workflow data.")
+      .optional(),
+    S3KeyPrefix: z.string().min(1).max(100).regex(
+      new RegExp("^[a-zA-Z0-9!\\-_.*'()]+(?:/[a-zA-Z0-9!\\-_.*'()]+)*$"),
+    ).describe(
+      "An optional prefix for Amazon S3 object keys to organize exported data.",
+    ).optional(),
+  }).describe(
+    "Configuration settings for exporting workflow execution data and logs to Amazon S3.",
+  ).optional(),
+  Name: z.string().min(1).max(40).regex(new RegExp("^[a-zA-Z0-9_-]{1,40}$"))
+    .describe(
+      "The name of the workflow definition. Must be unique within your account and region.",
+    ).optional(),
+});
+
+export const model = {
+  type: "@swamp/aws/novaact/workflow-definition",
+  version: "2026.04.03.1",
+  globalArguments: GlobalArgsSchema,
+  inputsSchema: InputsSchema,
+  resources: {
+    state: {
+      description: "NovaAct WorkflowDefinition resource state",
+      schema: StateSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    create: {
+      description: "Create a NovaAct WorkflowDefinition",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const desiredState: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(g)) {
+          if (key === "name") continue;
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await createResource(
+          "AWS::NovaAct::WorkflowDefinition",
+          desiredState,
+        ) as StateData;
+        const instanceName = g.name?.toString() ?? "current";
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    get: {
+      description: "Get a NovaAct WorkflowDefinition",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the NovaAct WorkflowDefinition",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const result = await readResource(
+          "AWS::NovaAct::WorkflowDefinition",
+          args.identifier,
+        ) as StateData;
+        const instanceName = context.globalArgs.name?.toString() ??
+          args.identifier;
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    delete: {
+      description: "Delete a NovaAct WorkflowDefinition",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the NovaAct WorkflowDefinition",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const { existed } = await deleteResource(
+          "AWS::NovaAct::WorkflowDefinition",
+          args.identifier,
+        );
+        const instanceName = context.globalArgs.name?.toString() ??
+          args.identifier;
+        const handle = await context.writeResource("state", instanceName, {
+          identifier: args.identifier,
+          existed,
+          status: existed ? "deleted" : "not_found",
+          deletedAt: new Date().toISOString(),
+        });
+        return { dataHandles: [handle] };
+      },
+    },
+    sync: {
+      description: "Sync NovaAct WorkflowDefinition state from AWS",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = g.name?.toString() ?? "current";
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const identifier = existing.Arn?.toString();
+        if (!identifier) {
+          throw new Error("No identifier found in existing state");
+        }
+        try {
+          const result = await readResource(
+            "AWS::NovaAct::WorkflowDefinition",
+            identifier,
+          ) as StateData;
+          const handle = await context.writeResource(
+            "state",
+            instanceName,
+            result,
+          );
+          return { dataHandles: [handle] };
+        } catch (error: unknown) {
+          if (isResourceNotFoundError(error)) {
+            const handle = await context.writeResource("state", instanceName, {
+              identifier,
+              status: "not_found",
+              syncedAt: new Date().toISOString(),
+            });
+            return { dataHandles: [handle] };
+          }
+          throw error;
+        }
+      },
+    },
+  },
+};

--- a/model/aws/novaact/manifest.yaml
+++ b/model/aws/novaact/manifest.yaml
@@ -1,0 +1,17 @@
+# Auto-generated manifest. Re-generate with the appropriate deno task.
+manifestVersion: 1
+name: "@swamp/aws/novaact"
+version: "2026.04.03.1"
+description: "AWS NOVAACT infrastructure models"
+labels:
+  - aws
+  - novaact
+  - cloud
+  - infrastructure
+releaseNotes: |
+  - Added: workflow_definition
+models:
+  - workflow_definition.ts
+additionalFiles:
+  - LICENSE.txt
+  - README.md

--- a/model/aws/quicksight/extensions/models/data_set.ts
+++ b/model/aws/quicksight/extensions/models/data_set.ts
@@ -1074,7 +1074,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/quicksight/data-set",
-  version: "2026.04.01.2",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -1086,8 +1086,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/quicksight/extensions/models/data_source.ts
+++ b/model/aws/quicksight/extensions/models/data_source.ts
@@ -719,7 +719,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/quicksight/data-source",
-  version: "2026.04.01.2",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -731,8 +731,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/quicksight/manifest.yaml
+++ b/model/aws/quicksight/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/quicksight"
-version: "2026.04.01.2"
+version: "2026.04.03.1"
 description: "AWS QUICKSIGHT infrastructure models"
 labels:
   - aws

--- a/model/aws/rds/extensions/models/dbcluster.ts
+++ b/model/aws/rds/extensions/models/dbcluster.ts
@@ -331,6 +331,7 @@ const StateSchema = z.object({
   SourceDbClusterResourceId: z.string().optional(),
   SourceRegion: z.string().optional(),
   StorageEncrypted: z.boolean().optional(),
+  StorageEncryptionType: z.string().optional(),
   StorageThroughput: z.number().optional(),
   StorageType: z.string().optional(),
   Tags: z.array(TagSchema).optional(),
@@ -562,10 +563,15 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/rds/dbcluster",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.03.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/rds/manifest.yaml
+++ b/model/aws/rds/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/rds"
-version: "2026.04.01.1"
+version: "2026.04.03.1"
 description: "AWS RDS infrastructure models"
 labels:
   - aws
@@ -9,7 +9,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: custom_dbengine_version, dbcluster, dbcluster_parameter_group, dbinstance, dbparameter_group, dbproxy, dbproxy_endpoint, dbproxy_target_group, dbshard_group, dbsubnet_group, event_subscription, global_cluster, integration, option_group
+  - Updated: dbcluster
 models:
   - custom_dbengine_version.ts
   - dbcluster.ts

--- a/model/aws/securityagent/extensions/models/agent_space.ts
+++ b/model/aws/securityagent/extensions/models/agent_space.ts
@@ -161,7 +161,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/securityagent/agent-space",
-  version: "2026.04.01.3",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.2",
@@ -173,8 +173,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/securityagent/extensions/models/application.ts
+++ b/model/aws/securityagent/extensions/models/application.ts
@@ -60,7 +60,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/securityagent/application",
-  version: "2026.04.01.3",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.2",
@@ -72,8 +72,12 @@ export const model = {
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.03.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
-
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
   resources: {

--- a/model/aws/securityagent/manifest.yaml
+++ b/model/aws/securityagent/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/securityagent"
-version: "2026.04.01.3"
+version: "2026.04.03.1"
 description: "AWS SECURITYAGENT infrastructure models"
 labels:
   - aws

--- a/model/aws/sso/extensions/models/application.ts
+++ b/model/aws/sso/extensions/models/application.ts
@@ -42,14 +42,14 @@ const GlobalArgsSchema = z.object({
   ).optional(),
   InstanceArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "^arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}$",
+      "^arn:aws(-[a-z]{1,5}){0,3}:sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}$",
     ),
   ).describe(
     "The ARN of the instance of IAM Identity Center under which the operation will run",
   ),
   ApplicationProviderArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "^arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso::aws:applicationProvider/[a-zA-Z0-9-/]+$",
+      "^arn:aws(-[a-z]{1,5}){0,3}:sso::aws:applicationProvider/[a-zA-Z0-9-/]+$",
     ),
   ).describe(
     "The ARN of the application provider under which the operation will run",
@@ -96,14 +96,14 @@ const InputsSchema = z.object({
   ).optional(),
   InstanceArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "^arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}$",
+      "^arn:aws(-[a-z]{1,5}){0,3}:sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}$",
     ),
   ).describe(
     "The ARN of the instance of IAM Identity Center under which the operation will run",
   ).optional(),
   ApplicationProviderArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "^arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso::aws:applicationProvider/[a-zA-Z0-9-/]+$",
+      "^arn:aws(-[a-z]{1,5}){0,3}:sso::aws:applicationProvider/[a-zA-Z0-9-/]+$",
     ),
   ).describe(
     "The ARN of the application provider under which the operation will run",
@@ -126,10 +126,15 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/sso/application",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.03.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/sso/extensions/models/application_assignment.ts
+++ b/model/aws/sso/extensions/models/application_assignment.ts
@@ -17,7 +17,7 @@ const GlobalArgsSchema = z.object({
   ),
   ApplicationArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso::\\d{12}:application/(sso)?ins-[a-zA-Z0-9-.]{16}/apl-[a-zA-Z0-9]{16}",
+      "arn:aws(-[a-z]{1,5}){0,3}:sso::\\d{12}:application/(sso)?ins-[a-zA-Z0-9-.]{16}/apl-[a-zA-Z0-9]{16}",
     ),
   ).describe("The ARN of the application."),
   PrincipalType: z.enum(["USER", "GROUP"]).describe(
@@ -44,7 +44,7 @@ const InputsSchema = z.object({
   name: z.string().optional(),
   ApplicationArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso::\\d{12}:application/(sso)?ins-[a-zA-Z0-9-.]{16}/apl-[a-zA-Z0-9]{16}",
+      "arn:aws(-[a-z]{1,5}){0,3}:sso::\\d{12}:application/(sso)?ins-[a-zA-Z0-9-.]{16}/apl-[a-zA-Z0-9]{16}",
     ),
   ).describe("The ARN of the application.").optional(),
   PrincipalType: z.enum(["USER", "GROUP"]).describe(
@@ -61,10 +61,15 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/sso/application-assignment",
-  version: "2026.04.01.1",
+  version: "2026.04.03.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.03.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/sso/manifest.yaml
+++ b/model/aws/sso/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/sso"
-version: "2026.04.01.1"
+version: "2026.04.03.1"
 description: "AWS SSO infrastructure models"
 labels:
   - aws
@@ -9,7 +9,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: application, application_assignment, assignment, instance, instance_access_control_attribute_configuration, permission_set
+  - Updated: application, application_assignment
 models:
   - application.ts
   - application_assignment.ts


### PR DESCRIPTION
## Summary

Automated regeneration of extension models from upstream provider schemas.

### Changes

- **aws**: 46 files changed


### Schema Sources

- **AWS**: CloudFormation Resource Schema
- **GCP**: Google Discovery Documents
- **Hetzner**: Hetzner Cloud OpenAPI spec
- **DigitalOcean**: DigitalOcean OpenAPI spec

### Review Notes

- Files under `model/` are auto-generated — review the `manifest.yaml` diffs for version changes
- CalVer versioning with content-based change detection ensures versions only bump when content changes
- Publishing happens automatically when this PR is merged (via the publish workflow)

