### PR TITLE
Fix spurious version bumps from blank line after upgrades block

### DIFF
--- a/codegen/shared/upgradesGenerator.ts
+++ b/codegen/shared/upgradesGenerator.ts
@@ -106,7 +106,9 @@ export function stripUpgradesBlock(content: string): string {
     i++;
   }
 
-  // Include the trailing comma and newline if present
+  // Include the trailing comma, newline, and any blank lines after the block.
+  // deno fmt may insert blank lines after multi-entry arrays; stripping them
+  // prevents phantom diffs in version change detection.
   let end = i;
   while (
     end < content.length && (content[end] === "," || content[end] === " ")
@@ -114,6 +116,10 @@ export function stripUpgradesBlock(content: string): string {
     end++;
   }
   if (end < content.length && content[end] === "\n") {
+    end++;
+  }
+  // Strip any additional blank lines that follow
+  while (end < content.length && content[end] === "\n") {
     end++;
   }
 


### PR DESCRIPTION
## Summary

- `stripUpgradesBlock()` strips the `upgrades: [...]` array for content comparison during version detection, but `deno fmt` inserts a blank line after the closing `],` when the array has 2+ entries
- This surviving blank line caused a phantom diff against the candidate code (generated without upgrades), triggering a spurious version bump on every regeneration run
- Each run added a new "No schema changes" upgrade entry and bumped the version, cascading indefinitely — this is what caused all ~260 GCP models to bump in PR #40 despite no schema changes
- Fix: strip any trailing blank lines after the upgrades block in `stripUpgradesBlock()`

## Test plan

- [x] Verified the fix with a standalone test script reproducing the exact scenario
- [x] `deno check` and `deno lint` pass on modified files
- [ ] Next daily regeneration run should show zero GCP model changes (versions stay unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)