### PR TITLE
chore: regenerate models from upstream schemas

### DIFF
--- a/model/aws/bedrockagentcore/extensions/models/oauth2credential_provider.ts
+++ b/model/aws/bedrockagentcore/extensions/models/oauth2credential_provider.ts
@@ -1,0 +1,482 @@
+// Auto-generated extension model for @swamp/aws/bedrockagentcore/oauth2credential-provider
+// Do not edit manually. Re-generate with: deno task generate:aws
+
+// deno-lint-ignore-file no-explicit-any
+
+import { z } from "zod";
+import {
+  createResource,
+  deleteResource,
+  isResourceNotFoundError,
+  readResource,
+  updateResource,
+} from "./_lib/aws.ts";
+
+export const Oauth2AuthorizationServerMetadataSchema = z.object({
+  Issuer: z.string().describe(
+    "The issuer URL for the OAuth2 authorization server",
+  ),
+  AuthorizationEndpoint: z.string().describe("The authorization endpoint URL"),
+  TokenEndpoint: z.string().describe("The token endpoint URL"),
+  ResponseTypes: z.array(z.string()).describe("The supported response types")
+    .optional(),
+});
+
+export const Oauth2DiscoverySchema = z.object({
+  DiscoveryUrl: z.string().regex(
+    new RegExp("^.+/\\.well-known/openid-configuration$"),
+  ).describe("The discovery URL for the OAuth2 provider").optional(),
+  AuthorizationServerMetadata: Oauth2AuthorizationServerMetadataSchema.describe(
+    "Authorization server metadata for the OAuth2 provider",
+  ).optional(),
+});
+
+export const CustomOauth2ProviderConfigInputSchema = z.object({
+  OauthDiscovery: Oauth2DiscoverySchema.describe(
+    "Discovery information for an OAuth2 provider",
+  ),
+  ClientId: z.string().min(1).max(256).describe(
+    "The client ID for the custom OAuth2 provider",
+  ),
+  ClientSecret: z.string().min(1).max(2048).describe(
+    "The client secret for the custom OAuth2 provider",
+  ),
+});
+
+export const GoogleOauth2ProviderConfigInputSchema = z.object({
+  ClientId: z.string().min(1).max(256),
+  ClientSecret: z.string().min(1).max(2048),
+});
+
+export const GithubOauth2ProviderConfigInputSchema = z.object({
+  ClientId: z.string().min(1).max(256),
+  ClientSecret: z.string().min(1).max(2048),
+});
+
+export const SlackOauth2ProviderConfigInputSchema = z.object({
+  ClientId: z.string().min(1).max(256),
+  ClientSecret: z.string().min(1).max(2048),
+});
+
+export const SalesforceOauth2ProviderConfigInputSchema = z.object({
+  ClientId: z.string().min(1).max(256),
+  ClientSecret: z.string().min(1).max(2048),
+});
+
+export const MicrosoftOauth2ProviderConfigInputSchema = z.object({
+  ClientId: z.string().min(1).max(256),
+  ClientSecret: z.string().min(1).max(2048),
+  TenantId: z.string().min(1).max(2048).describe(
+    "The Microsoft Entra ID tenant ID",
+  ).optional(),
+});
+
+export const AtlassianOauth2ProviderConfigInputSchema = z.object({
+  ClientId: z.string().min(1).max(256),
+  ClientSecret: z.string().min(1).max(2048),
+});
+
+export const LinkedinOauth2ProviderConfigInputSchema = z.object({
+  ClientId: z.string().min(1).max(256),
+  ClientSecret: z.string().min(1).max(2048),
+});
+
+export const IncludedOauth2ProviderConfigInputSchema = z.object({
+  ClientId: z.string().min(1).max(256),
+  ClientSecret: z.string().min(1).max(2048),
+  Issuer: z.string().describe(
+    "Token issuer of your isolated OAuth2 application tenant",
+  ).optional(),
+  AuthorizationEndpoint: z.string().describe(
+    "OAuth2 authorization endpoint for your isolated OAuth2 application tenant",
+  ).optional(),
+  TokenEndpoint: z.string().describe(
+    "OAuth2 token endpoint for your isolated OAuth2 application tenant",
+  ).optional(),
+});
+
+export const TagSchema = z.object({
+  Key: z.string().min(1).max(128).regex(
+    new RegExp("^[a-zA-Z0-9\\s._:/=+@-]*$"),
+  ),
+  Value: z.string().min(0).max(256).regex(
+    new RegExp("^[a-zA-Z0-9\\s._:/=+@-]*$"),
+  ),
+});
+
+const GlobalArgsSchema = z.object({
+  name: z.string().describe(
+    "Instance name for this resource (used as the unique identifier in the factory pattern)",
+  ),
+  Name: z.string().min(1).max(128).regex(new RegExp("^[a-zA-Z0-9\\-_]+$"))
+    .describe("The name of the OAuth2 credential provider"),
+  CredentialProviderVendor: z.enum([
+    "GoogleOauth2",
+    "GithubOauth2",
+    "SlackOauth2",
+    "SalesforceOauth2",
+    "MicrosoftOauth2",
+    "CustomOauth2",
+    "AtlassianOauth2",
+    "LinkedinOauth2",
+    "XOauth2",
+    "OktaOauth2",
+    "OneLoginOauth2",
+    "PingOneOauth2",
+    "FacebookOauth2",
+    "YandexOauth2",
+    "RedditOauth2",
+    "ZoomOauth2",
+    "TwitchOauth2",
+    "SpotifyOauth2",
+    "DropboxOauth2",
+    "NotionOauth2",
+    "HubspotOauth2",
+    "CyberArkOauth2",
+    "FusionAuthOauth2",
+    "Auth0Oauth2",
+    "CognitoOauth2",
+  ]).describe("The vendor of the OAuth2 credential provider"),
+  Oauth2ProviderConfigInput: z.object({
+    CustomOauth2ProviderConfig: CustomOauth2ProviderConfigInputSchema.describe(
+      "Input configuration for a custom OAuth2 provider",
+    ).optional(),
+    GoogleOauth2ProviderConfig: GoogleOauth2ProviderConfigInputSchema.describe(
+      "Input configuration for a Google OAuth2 provider",
+    ).optional(),
+    GithubOauth2ProviderConfig: GithubOauth2ProviderConfigInputSchema.describe(
+      "Input configuration for a GitHub OAuth2 provider",
+    ).optional(),
+    SlackOauth2ProviderConfig: SlackOauth2ProviderConfigInputSchema.describe(
+      "Input configuration for a Slack OAuth2 provider",
+    ).optional(),
+    SalesforceOauth2ProviderConfig: SalesforceOauth2ProviderConfigInputSchema
+      .describe("Input configuration for a Salesforce OAuth2 provider")
+      .optional(),
+    MicrosoftOauth2ProviderConfig: MicrosoftOauth2ProviderConfigInputSchema
+      .describe("Input configuration for a Microsoft OAuth2 provider")
+      .optional(),
+    AtlassianOauth2ProviderConfig: AtlassianOauth2ProviderConfigInputSchema
+      .describe("Input configuration for an Atlassian OAuth2 provider")
+      .optional(),
+    LinkedinOauth2ProviderConfig: LinkedinOauth2ProviderConfigInputSchema
+      .describe("Input configuration for a LinkedIn OAuth2 provider")
+      .optional(),
+    IncludedOauth2ProviderConfig: IncludedOauth2ProviderConfigInputSchema
+      .describe(
+        "Input configuration for a supported non-custom OAuth2 provider",
+      ).optional(),
+  }).describe("The configuration settings for the OAuth2 provider").optional(),
+  ClientSecretArn: z.object({
+    SecretArn: z.string().regex(
+      new RegExp(
+        "^arn:(aws|aws-us-gov):secretsmanager:[A-Za-z0-9-]{1,64}:[0-9]{12}:secret:[a-zA-Z0-9-_/+=.@!]+$",
+      ),
+    ).describe("The ARN of the secret in AWS Secrets Manager"),
+  }).describe("The ARN of the client secret in AWS Secrets Manager").optional(),
+  Oauth2ProviderConfigOutput: z.object({
+    OauthDiscovery: Oauth2DiscoverySchema.describe(
+      "Discovery information for an OAuth2 provider",
+    ).optional(),
+    ClientId: z.string().min(1).max(256).optional(),
+  }).describe("The output configuration for the OAuth2 provider").optional(),
+  Tags: z.array(TagSchema).describe(
+    "Tags to assign to the OAuth2 credential provider",
+  ).optional(),
+});
+
+const StateSchema = z.object({
+  Name: z.string().optional(),
+  CredentialProviderVendor: z.string().optional(),
+  Oauth2ProviderConfigInput: z.object({
+    CustomOauth2ProviderConfig: CustomOauth2ProviderConfigInputSchema,
+    GoogleOauth2ProviderConfig: GoogleOauth2ProviderConfigInputSchema,
+    GithubOauth2ProviderConfig: GithubOauth2ProviderConfigInputSchema,
+    SlackOauth2ProviderConfig: SlackOauth2ProviderConfigInputSchema,
+    SalesforceOauth2ProviderConfig: SalesforceOauth2ProviderConfigInputSchema,
+    MicrosoftOauth2ProviderConfig: MicrosoftOauth2ProviderConfigInputSchema,
+    AtlassianOauth2ProviderConfig: AtlassianOauth2ProviderConfigInputSchema,
+    LinkedinOauth2ProviderConfig: LinkedinOauth2ProviderConfigInputSchema,
+    IncludedOauth2ProviderConfig: IncludedOauth2ProviderConfigInputSchema,
+  }).optional(),
+  CredentialProviderArn: z.string(),
+  ClientSecretArn: z.object({
+    SecretArn: z.string(),
+  }).optional(),
+  CallbackUrl: z.string().optional(),
+  Oauth2ProviderConfigOutput: z.object({
+    OauthDiscovery: Oauth2DiscoverySchema,
+    ClientId: z.string(),
+  }).optional(),
+  CreatedTime: z.string().optional(),
+  LastUpdatedTime: z.string().optional(),
+  Tags: z.array(TagSchema).optional(),
+}).passthrough();
+
+type StateData = z.infer<typeof StateSchema>;
+
+const InputsSchema = z.object({
+  name: z.string().optional(),
+  Name: z.string().min(1).max(128).regex(new RegExp("^[a-zA-Z0-9\\-_]+$"))
+    .describe("The name of the OAuth2 credential provider").optional(),
+  CredentialProviderVendor: z.enum([
+    "GoogleOauth2",
+    "GithubOauth2",
+    "SlackOauth2",
+    "SalesforceOauth2",
+    "MicrosoftOauth2",
+    "CustomOauth2",
+    "AtlassianOauth2",
+    "LinkedinOauth2",
+    "XOauth2",
+    "OktaOauth2",
+    "OneLoginOauth2",
+    "PingOneOauth2",
+    "FacebookOauth2",
+    "YandexOauth2",
+    "RedditOauth2",
+    "ZoomOauth2",
+    "TwitchOauth2",
+    "SpotifyOauth2",
+    "DropboxOauth2",
+    "NotionOauth2",
+    "HubspotOauth2",
+    "CyberArkOauth2",
+    "FusionAuthOauth2",
+    "Auth0Oauth2",
+    "CognitoOauth2",
+  ]).describe("The vendor of the OAuth2 credential provider").optional(),
+  Oauth2ProviderConfigInput: z.object({
+    CustomOauth2ProviderConfig: CustomOauth2ProviderConfigInputSchema.describe(
+      "Input configuration for a custom OAuth2 provider",
+    ).optional(),
+    GoogleOauth2ProviderConfig: GoogleOauth2ProviderConfigInputSchema.describe(
+      "Input configuration for a Google OAuth2 provider",
+    ).optional(),
+    GithubOauth2ProviderConfig: GithubOauth2ProviderConfigInputSchema.describe(
+      "Input configuration for a GitHub OAuth2 provider",
+    ).optional(),
+    SlackOauth2ProviderConfig: SlackOauth2ProviderConfigInputSchema.describe(
+      "Input configuration for a Slack OAuth2 provider",
+    ).optional(),
+    SalesforceOauth2ProviderConfig: SalesforceOauth2ProviderConfigInputSchema
+      .describe("Input configuration for a Salesforce OAuth2 provider")
+      .optional(),
+    MicrosoftOauth2ProviderConfig: MicrosoftOauth2ProviderConfigInputSchema
+      .describe("Input configuration for a Microsoft OAuth2 provider")
+      .optional(),
+    AtlassianOauth2ProviderConfig: AtlassianOauth2ProviderConfigInputSchema
+      .describe("Input configuration for an Atlassian OAuth2 provider")
+      .optional(),
+    LinkedinOauth2ProviderConfig: LinkedinOauth2ProviderConfigInputSchema
+      .describe("Input configuration for a LinkedIn OAuth2 provider")
+      .optional(),
+    IncludedOauth2ProviderConfig: IncludedOauth2ProviderConfigInputSchema
+      .describe(
+        "Input configuration for a supported non-custom OAuth2 provider",
+      ).optional(),
+  }).describe("The configuration settings for the OAuth2 provider").optional(),
+  ClientSecretArn: z.object({
+    SecretArn: z.string().regex(
+      new RegExp(
+        "^arn:(aws|aws-us-gov):secretsmanager:[A-Za-z0-9-]{1,64}:[0-9]{12}:secret:[a-zA-Z0-9-_/+=.@!]+$",
+      ),
+    ).describe("The ARN of the secret in AWS Secrets Manager").optional(),
+  }).describe("The ARN of the client secret in AWS Secrets Manager").optional(),
+  Oauth2ProviderConfigOutput: z.object({
+    OauthDiscovery: Oauth2DiscoverySchema.describe(
+      "Discovery information for an OAuth2 provider",
+    ).optional(),
+    ClientId: z.string().min(1).max(256).optional(),
+  }).describe("The output configuration for the OAuth2 provider").optional(),
+  Tags: z.array(TagSchema).describe(
+    "Tags to assign to the OAuth2 credential provider",
+  ).optional(),
+});
+
+export const model = {
+  type: "@swamp/aws/bedrockagentcore/oauth2credential-provider",
+  version: "2026.04.04.1",
+  globalArguments: GlobalArgsSchema,
+  inputsSchema: InputsSchema,
+  resources: {
+    state: {
+      description: "BedrockAgentCore OAuth2CredentialProvider resource state",
+      schema: StateSchema,
+      lifetime: "infinite",
+      garbageCollection: 10,
+    },
+  },
+  methods: {
+    create: {
+      description: "Create a BedrockAgentCore OAuth2CredentialProvider",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const desiredState: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(g)) {
+          if (key === "name") continue;
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await createResource(
+          "AWS::BedrockAgentCore::OAuth2CredentialProvider",
+          desiredState,
+        ) as StateData;
+        const instanceName = (g.name?.toString() ?? "current").replace(
+          /[\/\\]/g,
+          "_",
+        ).replace(/\.\./g, "_").replace(/\0/g, "");
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    get: {
+      description: "Get a BedrockAgentCore OAuth2CredentialProvider",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the BedrockAgentCore OAuth2CredentialProvider",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const result = await readResource(
+          "AWS::BedrockAgentCore::OAuth2CredentialProvider",
+          args.identifier,
+        ) as StateData;
+        const instanceName =
+          (context.globalArgs.name?.toString() ?? args.identifier).replace(
+            /[\/\\]/g,
+            "_",
+          ).replace(/\.\./g, "_").replace(/\0/g, "");
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    update: {
+      description: "Update a BedrockAgentCore OAuth2CredentialProvider",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = (g.name?.toString() ?? "current").replace(
+          /[\/\\]/g,
+          "_",
+        ).replace(/\.\./g, "_").replace(/\0/g, "");
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const identifier = existing.CredentialProviderArn?.toString();
+        if (!identifier) {
+          throw new Error("No identifier found in existing state");
+        }
+        const currentState = await readResource(
+          "AWS::BedrockAgentCore::OAuth2CredentialProvider",
+          identifier,
+        ) as StateData;
+        const desiredState: Record<string, unknown> = { ...currentState };
+        for (const [key, value] of Object.entries(g)) {
+          if (key === "name") continue;
+          if (value !== undefined) desiredState[key] = value;
+        }
+        const result = await updateResource(
+          "AWS::BedrockAgentCore::OAuth2CredentialProvider",
+          identifier,
+          currentState,
+          desiredState,
+          ["Name", "CredentialProviderVendor"],
+        );
+        const handle = await context.writeResource(
+          "state",
+          instanceName,
+          result,
+        );
+        return { dataHandles: [handle] };
+      },
+    },
+    delete: {
+      description: "Delete a BedrockAgentCore OAuth2CredentialProvider",
+      arguments: z.object({
+        identifier: z.string().describe(
+          "The primary identifier of the BedrockAgentCore OAuth2CredentialProvider",
+        ),
+      }),
+      execute: async (args: { identifier: string }, context: any) => {
+        const { existed } = await deleteResource(
+          "AWS::BedrockAgentCore::OAuth2CredentialProvider",
+          args.identifier,
+        );
+        const instanceName =
+          (context.globalArgs.name?.toString() ?? args.identifier).replace(
+            /[\/\\]/g,
+            "_",
+          ).replace(/\.\./g, "_").replace(/\0/g, "");
+        const handle = await context.writeResource("state", instanceName, {
+          identifier: args.identifier,
+          existed,
+          status: existed ? "deleted" : "not_found",
+          deletedAt: new Date().toISOString(),
+        });
+        return { dataHandles: [handle] };
+      },
+    },
+    sync: {
+      description:
+        "Sync BedrockAgentCore OAuth2CredentialProvider state from AWS",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, never>, context: any) => {
+        const g = context.globalArgs;
+        const instanceName = (g.name?.toString() ?? "current").replace(
+          /[\/\\]/g,
+          "_",
+        ).replace(/\.\./g, "_").replace(/\0/g, "");
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          instanceName,
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        const identifier = existing.CredentialProviderArn?.toString();
+        if (!identifier) {
+          throw new Error("No identifier found in existing state");
+        }
+        try {
+          const result = await readResource(
+            "AWS::BedrockAgentCore::OAuth2CredentialProvider",
+            identifier,
+          ) as StateData;
+          const handle = await context.writeResource(
+            "state",
+            instanceName,
+            result,
+          );
+          return { dataHandles: [handle] };
+        } catch (error: unknown) {
+          if (isResourceNotFoundError(error)) {
+            const handle = await context.writeResource("state", instanceName, {
+              identifier,
+              status: "not_found",
+              syncedAt: new Date().toISOString(),
+            });
+            return { dataHandles: [handle] };
+          }
+          throw error;
+        }
+      },
+    },
+  },
+};

--- a/model/aws/bedrockagentcore/manifest.yaml
+++ b/model/aws/bedrockagentcore/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/bedrockagentcore"
-version: "2026.04.03.3"
+version: "2026.04.04.1"
 description: "AWS BEDROCKAGENTCORE infrastructure models"
 labels:
   - aws
@@ -9,7 +9,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: api_key_credential_provider, browser_custom, browser_profile, code_interpreter_custom, evaluator, gateway, gateway_target, memory, online_evaluation_config, policy, policy_engine, runtime, runtime_endpoint, workload_identity
+  - Added: oauth2credential_provider
 models:
   - api_key_credential_provider.ts
   - browser_custom.ts
@@ -19,6 +19,7 @@ models:
   - gateway.ts
   - gateway_target.ts
   - memory.ts
+  - oauth2credential_provider.ts
   - online_evaluation_config.ts
   - policy.ts
   - policy_engine.ts

--- a/model/gcp/bigquerydatapolicy/extensions/models/datapolicies.ts
+++ b/model/gcp/bigquerydatapolicy/extensions/models/datapolicies.ts
@@ -88,16 +88,6 @@ const DELETE_CONFIG = {
 
 const GlobalArgsSchema = z.object({
   dataPolicy: z.object({
-    dataGovernanceTag: z.object({
-      key: z.string().describe(
-        "Optional. Tag keys are globally unique. Tag key is expected to be in the namespaced format, for example `parent-id/pii` where `parent-id` is the ID of the parent organization or project resource for this tag key.",
-      ).optional(),
-      value: z.string().describe(
-        "Optional. Specifies the tag value as the short name, for example `sensitive`.",
-      ).optional(),
-    }).describe(
-      "Data Governance tag This is a namespaced name specifying the key and the value. For example: `project-id/pii/sensitive`.",
-    ).optional(),
     dataMaskingPolicy: z.object({
       predefinedExpression: z.enum([
         "PREDEFINED_EXPRESSION_UNSPECIFIED",
@@ -141,16 +131,6 @@ const GlobalArgsSchema = z.object({
   }).describe("Represents the label-policy binding.").optional(),
   dataPolicyId: z.string().describe(
     "Output only. User-assigned (human readable) ID of the data policy that needs to be unique within a project. Used as {data_policy_id} in part of the resource name.",
-  ).optional(),
-  dataGovernanceTag: z.object({
-    key: z.string().describe(
-      "Optional. Tag keys are globally unique. Tag key is expected to be in the namespaced format, for example `parent-id/pii` where `parent-id` is the ID of the parent organization or project resource for this tag key.",
-    ).optional(),
-    value: z.string().describe(
-      "Optional. Specifies the tag value as the short name, for example `sensitive`.",
-    ).optional(),
-  }).describe(
-    "Data Governance tag This is a namespaced name specifying the key and the value. For example: `project-id/pii/sensitive`.",
   ).optional(),
   dataMaskingPolicy: z.object({
     predefinedExpression: z.enum([
@@ -195,10 +175,6 @@ const GlobalArgsSchema = z.object({
 });
 
 const StateSchema = z.object({
-  dataGovernanceTag: z.object({
-    key: z.string(),
-    value: z.string(),
-  }).optional(),
   dataMaskingPolicy: z.object({
     predefinedExpression: z.string(),
     routine: z.string(),
@@ -216,16 +192,6 @@ type StateData = z.infer<typeof StateSchema>;
 
 const InputsSchema = z.object({
   dataPolicy: z.object({
-    dataGovernanceTag: z.object({
-      key: z.string().describe(
-        "Optional. Tag keys are globally unique. Tag key is expected to be in the namespaced format, for example `parent-id/pii` where `parent-id` is the ID of the parent organization or project resource for this tag key.",
-      ).optional(),
-      value: z.string().describe(
-        "Optional. Specifies the tag value as the short name, for example `sensitive`.",
-      ).optional(),
-    }).describe(
-      "Data Governance tag This is a namespaced name specifying the key and the value. For example: `project-id/pii/sensitive`.",
-    ).optional(),
     dataMaskingPolicy: z.object({
       predefinedExpression: z.enum([
         "PREDEFINED_EXPRESSION_UNSPECIFIED",
@@ -269,16 +235,6 @@ const InputsSchema = z.object({
   }).describe("Represents the label-policy binding.").optional(),
   dataPolicyId: z.string().describe(
     "Output only. User-assigned (human readable) ID of the data policy that needs to be unique within a project. Used as {data_policy_id} in part of the resource name.",
-  ).optional(),
-  dataGovernanceTag: z.object({
-    key: z.string().describe(
-      "Optional. Tag keys are globally unique. Tag key is expected to be in the namespaced format, for example `parent-id/pii` where `parent-id` is the ID of the parent organization or project resource for this tag key.",
-    ).optional(),
-    value: z.string().describe(
-      "Optional. Specifies the tag value as the short name, for example `sensitive`.",
-    ).optional(),
-  }).describe(
-    "Data Governance tag This is a namespaced name specifying the key and the value. For example: `project-id/pii/sensitive`.",
   ).optional(),
   dataMaskingPolicy: z.object({
     predefinedExpression: z.enum([
@@ -324,7 +280,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/bigquerydatapolicy/datapolicies",
-  version: "2026.04.03.3",
+  version: "2026.04.04.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -368,6 +324,14 @@ export const model = {
       toVersion: "2026.04.03.3",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.1",
+      description: "Removed: dataGovernanceTag",
+      upgradeAttributes: (old: Record<string, unknown>) => {
+        const { dataGovernanceTag: _dataGovernanceTag, ...rest } = old;
+        return rest;
+      },
     },
   ],
   globalArguments: GlobalArgsSchema,
@@ -475,9 +439,6 @@ export const model = {
         const body: Record<string, unknown> = {};
         if (g["dataPolicyId"] !== undefined) {
           body["dataPolicyId"] = g["dataPolicyId"];
-        }
-        if (g["dataGovernanceTag"] !== undefined) {
-          body["dataGovernanceTag"] = g["dataGovernanceTag"];
         }
         if (g["dataMaskingPolicy"] !== undefined) {
           body["dataMaskingPolicy"] = g["dataMaskingPolicy"];

--- a/model/gcp/bigquerydatapolicy/manifest.yaml
+++ b/model/gcp/bigquerydatapolicy/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/gcp/bigquerydatapolicy"
-version: "2026.04.03.3"
+version: "2026.04.04.1"
 description: "Google Cloud bigquerydatapolicy infrastructure models"
 labels:
   - gcp

--- a/model/gcp/compute/extensions/models/backendbuckets.ts
+++ b/model/gcp/compute/extensions/models/backendbuckets.ts
@@ -176,10 +176,9 @@ const GlobalArgsSchema = z.object({
   enableCdn: z.boolean().describe(
     "If true, enable Cloud CDN for this BackendBucket.",
   ).optional(),
-  loadBalancingScheme: z.enum(["EXTERNAL_MANAGED", "INTERNAL_MANAGED"])
-    .describe(
-      "The value can only be INTERNAL_MANAGED for cross-region internal layer 7 load balancer. If loadBalancingScheme is not specified, the backend bucket can be used by classic global external load balancers, or global application external load balancers, or both.",
-    ).optional(),
+  loadBalancingScheme: z.enum(["INTERNAL_MANAGED"]).describe(
+    "The value can only be INTERNAL_MANAGED for cross-region internal layer 7 load balancer. If loadBalancingScheme is not specified, the backend bucket can be used by classic global external load balancers, or global application external load balancers, or both.",
+  ).optional(),
   name: z.string().regex(new RegExp("[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?"))
     .describe(
       "Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply withRFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.",
@@ -231,7 +230,6 @@ const StateSchema = z.object({
   params: z.object({
     resourceManagerTags: z.record(z.string(), z.unknown()),
   }).optional(),
-  region: z.string().optional(),
   selfLink: z.string().optional(),
   usedBy: z.array(z.object({
     reference: z.string(),
@@ -317,10 +315,9 @@ const InputsSchema = z.object({
   enableCdn: z.boolean().describe(
     "If true, enable Cloud CDN for this BackendBucket.",
   ).optional(),
-  loadBalancingScheme: z.enum(["EXTERNAL_MANAGED", "INTERNAL_MANAGED"])
-    .describe(
-      "The value can only be INTERNAL_MANAGED for cross-region internal layer 7 load balancer. If loadBalancingScheme is not specified, the backend bucket can be used by classic global external load balancers, or global application external load balancers, or both.",
-    ).optional(),
+  loadBalancingScheme: z.enum(["INTERNAL_MANAGED"]).describe(
+    "The value can only be INTERNAL_MANAGED for cross-region internal layer 7 load balancer. If loadBalancingScheme is not specified, the backend bucket can be used by classic global external load balancers, or global application external load balancers, or both.",
+  ).optional(),
   name: z.string().regex(new RegExp("[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?"))
     .describe(
       "Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply withRFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.",
@@ -337,7 +334,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/backendbuckets",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -376,6 +373,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -650,34 +652,6 @@ export const model = {
           },
           params,
           body,
-        );
-        return { result };
-      },
-    },
-    list_usable: {
-      description: "list usable",
-      arguments: z.object({}),
-      execute: async (_args: Record<string, unknown>, _context: any) => {
-        const projectId = await getProjectId();
-        const params: Record<string, string> = { project: projectId };
-        const result = await createResource(
-          BASE_URL,
-          {
-            "id": "compute.backendBuckets.listUsable",
-            "path": "projects/{project}/global/backendBuckets/listUsable",
-            "httpMethod": "GET",
-            "parameterOrder": ["project"],
-            "parameters": {
-              "filter": { "location": "query" },
-              "maxResults": { "location": "query" },
-              "orderBy": { "location": "query" },
-              "pageToken": { "location": "query" },
-              "project": { "location": "path", "required": true },
-              "returnPartialSuccess": { "location": "query" },
-            },
-          },
-          params,
-          {},
         );
         return { result };
       },

--- a/model/gcp/compute/extensions/models/backendservices.ts
+++ b/model/gcp/compute/extensions/models/backendservices.ts
@@ -107,7 +107,6 @@ const GlobalArgsSchema = z.object({
     balancingMode: z.enum([
       "CONNECTION",
       "CUSTOM_METRICS",
-      "IN_FLIGHT",
       "RATE",
       "UTILIZATION",
     ]).describe(
@@ -147,15 +146,6 @@ const GlobalArgsSchema = z.object({
     maxConnectionsPerInstance: z.number().int().describe(
       "Defines a target maximum number of simultaneous connections. For usage guidelines, seeConnection balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isRATE.",
     ).optional(),
-    maxInFlightRequests: z.number().int().describe(
-      "Defines a maximum number of in-flight requests for the whole NEG or instance group. Not available if backend's balancingMode isRATE or CONNECTION.",
-    ).optional(),
-    maxInFlightRequestsPerEndpoint: z.number().int().describe(
-      "Defines a maximum number of in-flight requests for a single endpoint. Not available if backend's balancingMode is RATE or CONNECTION.",
-    ).optional(),
-    maxInFlightRequestsPerInstance: z.number().int().describe(
-      "Defines a maximum number of in-flight requests for a single VM. Not available if backend's balancingMode is RATE or CONNECTION.",
-    ).optional(),
     maxRate: z.number().int().describe(
       "Defines a maximum number of HTTP requests per second (RPS). For usage guidelines, seeRate balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isCONNECTION.",
     ).optional(),
@@ -179,8 +169,6 @@ const GlobalArgsSchema = z.object({
       .describe(
         "This field indicates whether this backend should be fully utilized before sending traffic to backends with default preference. The possible values are: - PREFERRED: Backends with this preference level will be filled up to their capacity limits first, based on RTT. - DEFAULT: If preferred backends don't have enough capacity, backends in this layer would be used and traffic would be assigned based on the load balancing algorithm you use. This is the default",
       ).optional(),
-    trafficDuration: z.enum(["LONG", "SHORT", "TRAFFIC_DURATION_UNSPECIFIED"])
-      .optional(),
   })).describe("The list of backends that serve this BackendService.")
     .optional(),
   cdnPolicy: z.object({
@@ -479,7 +467,7 @@ const GlobalArgsSchema = z.object({
     "WEIGHTED_MAGLEV",
     "WEIGHTED_ROUND_ROBIN",
   ]).describe(
-    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
+    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
   ).optional(),
   logConfig: z.object({
     enable: z.boolean().describe(
@@ -719,9 +707,6 @@ const StateSchema = z.object({
     maxConnections: z.number(),
     maxConnectionsPerEndpoint: z.number(),
     maxConnectionsPerInstance: z.number(),
-    maxInFlightRequests: z.number(),
-    maxInFlightRequestsPerEndpoint: z.number(),
-    maxInFlightRequestsPerInstance: z.number(),
     maxRate: z.number(),
     maxRatePerEndpoint: z.number(),
     maxRatePerInstance: z.number(),
@@ -730,7 +715,6 @@ const StateSchema = z.object({
       resourceUri: z.string(),
     }),
     preference: z.string(),
-    trafficDuration: z.string(),
   })).optional(),
   cdnPolicy: z.object({
     bypassCacheOnRequestHeaders: z.array(z.object({
@@ -934,7 +918,6 @@ const InputsSchema = z.object({
     balancingMode: z.enum([
       "CONNECTION",
       "CUSTOM_METRICS",
-      "IN_FLIGHT",
       "RATE",
       "UTILIZATION",
     ]).describe(
@@ -974,15 +957,6 @@ const InputsSchema = z.object({
     maxConnectionsPerInstance: z.number().int().describe(
       "Defines a target maximum number of simultaneous connections. For usage guidelines, seeConnection balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isRATE.",
     ).optional(),
-    maxInFlightRequests: z.number().int().describe(
-      "Defines a maximum number of in-flight requests for the whole NEG or instance group. Not available if backend's balancingMode isRATE or CONNECTION.",
-    ).optional(),
-    maxInFlightRequestsPerEndpoint: z.number().int().describe(
-      "Defines a maximum number of in-flight requests for a single endpoint. Not available if backend's balancingMode is RATE or CONNECTION.",
-    ).optional(),
-    maxInFlightRequestsPerInstance: z.number().int().describe(
-      "Defines a maximum number of in-flight requests for a single VM. Not available if backend's balancingMode is RATE or CONNECTION.",
-    ).optional(),
     maxRate: z.number().int().describe(
       "Defines a maximum number of HTTP requests per second (RPS). For usage guidelines, seeRate balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isCONNECTION.",
     ).optional(),
@@ -1006,8 +980,6 @@ const InputsSchema = z.object({
       .describe(
         "This field indicates whether this backend should be fully utilized before sending traffic to backends with default preference. The possible values are: - PREFERRED: Backends with this preference level will be filled up to their capacity limits first, based on RTT. - DEFAULT: If preferred backends don't have enough capacity, backends in this layer would be used and traffic would be assigned based on the load balancing algorithm you use. This is the default",
       ).optional(),
-    trafficDuration: z.enum(["LONG", "SHORT", "TRAFFIC_DURATION_UNSPECIFIED"])
-      .optional(),
   })).describe("The list of backends that serve this BackendService.")
     .optional(),
   cdnPolicy: z.object({
@@ -1306,7 +1278,7 @@ const InputsSchema = z.object({
     "WEIGHTED_MAGLEV",
     "WEIGHTED_ROUND_ROBIN",
   ]).describe(
-    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
+    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
   ).optional(),
   logConfig: z.object({
     enable: z.boolean().describe(
@@ -1532,7 +1504,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/backendservices",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1571,6 +1543,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/disks.ts
+++ b/model/gcp/compute/extensions/models/disks.ts
@@ -191,7 +191,7 @@ const GlobalArgsSchema = z.object({
       "VIRTIO_SCSI_MULTIQUEUE",
       "WINDOWS",
     ]).describe(
-      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
     ).optional(),
   })).describe(
     "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -477,7 +477,7 @@ const InputsSchema = z.object({
       "VIRTIO_SCSI_MULTIQUEUE",
       "WINDOWS",
     ]).describe(
-      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
     ).optional(),
   })).describe(
     "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -615,7 +615,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/disks",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -654,6 +654,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -1082,8 +1087,6 @@ export const model = {
     bulk_insert: {
       description: "bulk insert",
       arguments: z.object({
-        instantSnapshotGroupParameters: z.any().optional(),
-        snapshotGroupParameters: z.any().optional(),
         sourceConsistencyGroupPolicy: z.any().optional(),
       }),
       execute: async (args: Record<string, unknown>, context: any) => {
@@ -1092,13 +1095,6 @@ export const model = {
         const params: Record<string, string> = { project: projectId };
         if (g["zone"] !== undefined) params["zone"] = String(g["zone"]);
         const body: Record<string, unknown> = {};
-        if (args["instantSnapshotGroupParameters"] !== undefined) {
-          body["instantSnapshotGroupParameters"] =
-            args["instantSnapshotGroupParameters"];
-        }
-        if (args["snapshotGroupParameters"] !== undefined) {
-          body["snapshotGroupParameters"] = args["snapshotGroupParameters"];
-        }
         if (args["sourceConsistencyGroupPolicy"] !== undefined) {
           body["sourceConsistencyGroupPolicy"] =
             args["sourceConsistencyGroupPolicy"];
@@ -1177,13 +1173,10 @@ export const model = {
         locationHint: z.any().optional(),
         name: z.any().optional(),
         params: z.any().optional(),
-        region: z.any().optional(),
         satisfiesPzi: z.any().optional(),
         satisfiesPzs: z.any().optional(),
         selfLink: z.any().optional(),
         snapshotEncryptionKey: z.any().optional(),
-        snapshotGroupId: z.any().optional(),
-        snapshotGroupName: z.any().optional(),
         snapshotType: z.any().optional(),
         sourceDisk: z.any().optional(),
         sourceDiskEncryptionKey: z.any().optional(),
@@ -1267,7 +1260,6 @@ export const model = {
         }
         if (args["name"] !== undefined) body["name"] = args["name"];
         if (args["params"] !== undefined) body["params"] = args["params"];
-        if (args["region"] !== undefined) body["region"] = args["region"];
         if (args["satisfiesPzi"] !== undefined) {
           body["satisfiesPzi"] = args["satisfiesPzi"];
         }
@@ -1277,12 +1269,6 @@ export const model = {
         if (args["selfLink"] !== undefined) body["selfLink"] = args["selfLink"];
         if (args["snapshotEncryptionKey"] !== undefined) {
           body["snapshotEncryptionKey"] = args["snapshotEncryptionKey"];
-        }
-        if (args["snapshotGroupId"] !== undefined) {
-          body["snapshotGroupId"] = args["snapshotGroupId"];
-        }
-        if (args["snapshotGroupName"] !== undefined) {
-          body["snapshotGroupName"] = args["snapshotGroupName"];
         }
         if (args["snapshotType"] !== undefined) {
           body["snapshotType"] = args["snapshotType"];
@@ -1562,54 +1548,6 @@ export const model = {
             "httpMethod": "POST",
             "parameterOrder": ["project", "zone"],
             "parameters": {
-              "project": { "location": "path", "required": true },
-              "requestId": { "location": "query" },
-              "zone": { "location": "path", "required": true },
-            },
-          },
-          params,
-          body,
-        );
-        return { result };
-      },
-    },
-    update_kms_key: {
-      description: "update kms key",
-      arguments: z.object({
-        kmsKeyName: z.any().optional(),
-      }),
-      execute: async (args: Record<string, unknown>, context: any) => {
-        const g = context.globalArgs;
-        const projectId = await getProjectId();
-        const params: Record<string, string> = { project: projectId };
-        if (g["zone"] !== undefined) params["zone"] = String(g["zone"]);
-        const content = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          (g.name?.toString() ?? "current").replace(/[\/\\]/g, "_").replace(
-            /\.\./g,
-            "_",
-          ).replace(/\0/g, ""),
-        );
-        if (!content) {
-          throw new Error("No existing state found - run create or get first");
-        }
-        const existing = JSON.parse(new TextDecoder().decode(content));
-        params["disk"] = existing["name"]?.toString() ??
-          g["name"]?.toString() ?? "";
-        const body: Record<string, unknown> = {};
-        if (args["kmsKeyName"] !== undefined) {
-          body["kmsKeyName"] = args["kmsKeyName"];
-        }
-        const result = await createResource(
-          BASE_URL,
-          {
-            "id": "compute.disks.updateKmsKey",
-            "path": "projects/{project}/zones/{zone}/disks/{disk}/updateKmsKey",
-            "httpMethod": "POST",
-            "parameterOrder": ["project", "zone", "disk"],
-            "parameters": {
-              "disk": { "location": "path", "required": true },
               "project": { "location": "path", "required": true },
               "requestId": { "location": "query" },
               "zone": { "location": "path", "required": true },

--- a/model/gcp/compute/extensions/models/futurereservations.ts
+++ b/model/gcp/compute/extensions/models/futurereservations.ts
@@ -199,10 +199,6 @@ const GlobalArgsSchema = z.object({
       "Only applicable if FR is delivering to the same reservation. If set, all parent commitments will be extended to match the end date of the plan for this commitment.",
     ).optional(),
   }).optional(),
-  confidentialComputeType: z.enum([
-    "CONFIDENTIAL_COMPUTE_TYPE_TDX",
-    "CONFIDENTIAL_COMPUTE_TYPE_UNSPECIFIED",
-  ]).optional(),
   deploymentType: z.enum(["DENSE", "DEPLOYMENT_TYPE_UNSPECIFIED"]).describe(
     "Type of the deployment requested as part of future reservation.",
   ).optional(),
@@ -219,11 +215,6 @@ const GlobalArgsSchema = z.object({
   namePrefix: z.string().describe(
     "Name prefix for the reservations to be created at the time of delivery. The name prefix must comply with RFC1035. Maximum allowed length for name prefix is 20. Automatically created reservations name format will be -date-####.",
   ).optional(),
-  params: z.object({
-    resourceManagerTags: z.record(z.string(), z.string()).describe(
-      "Input only. Resource manager tags to be bound to the future reservation. Tag keys and values have the same definition as resource manager tags. Keys and values can be either in numeric format, such as `tagKeys/{tag_key_id}` and `tagValues/{tag_value_id}` or in namespaced format such as `{org_id|project_id}/{tag_key_short_name}` and `{tag_value_short_name}`. The field is ignored (both PUT & PATCH) when empty.",
-    ).optional(),
-  }).describe("Additional future reservation params.").optional(),
   planningStatus: z.enum(["DRAFT", "PLANNING_STATUS_UNSPECIFIED", "SUBMITTED"])
     .describe("Planning state before being submitted for evaluation")
     .optional(),
@@ -355,7 +346,6 @@ const StateSchema = z.object({
     commitmentPlan: z.string(),
     previousCommitmentTerms: z.string(),
   }).optional(),
-  confidentialComputeType: z.string().optional(),
   creationTimestamp: z.string().optional(),
   deploymentType: z.string().optional(),
   description: z.string().optional(),
@@ -364,9 +354,6 @@ const StateSchema = z.object({
   kind: z.string().optional(),
   name: z.string(),
   namePrefix: z.string().optional(),
-  params: z.object({
-    resourceManagerTags: z.record(z.string(), z.unknown()),
-  }).optional(),
   planningStatus: z.string().optional(),
   reservationMode: z.string().optional(),
   reservationName: z.string().optional(),
@@ -531,10 +518,6 @@ const InputsSchema = z.object({
       "Only applicable if FR is delivering to the same reservation. If set, all parent commitments will be extended to match the end date of the plan for this commitment.",
     ).optional(),
   }).optional(),
-  confidentialComputeType: z.enum([
-    "CONFIDENTIAL_COMPUTE_TYPE_TDX",
-    "CONFIDENTIAL_COMPUTE_TYPE_UNSPECIFIED",
-  ]).optional(),
   deploymentType: z.enum(["DENSE", "DEPLOYMENT_TYPE_UNSPECIFIED"]).describe(
     "Type of the deployment requested as part of future reservation.",
   ).optional(),
@@ -551,11 +534,6 @@ const InputsSchema = z.object({
   namePrefix: z.string().describe(
     "Name prefix for the reservations to be created at the time of delivery. The name prefix must comply with RFC1035. Maximum allowed length for name prefix is 20. Automatically created reservations name format will be -date-####.",
   ).optional(),
-  params: z.object({
-    resourceManagerTags: z.record(z.string(), z.string()).describe(
-      "Input only. Resource manager tags to be bound to the future reservation. Tag keys and values have the same definition as resource manager tags. Keys and values can be either in numeric format, such as `tagKeys/{tag_key_id}` and `tagValues/{tag_value_id}` or in namespaced format such as `{org_id|project_id}/{tag_key_short_name}` and `{tag_value_short_name}`. The field is ignored (both PUT & PATCH) when empty.",
-    ).optional(),
-  }).describe("Additional future reservation params.").optional(),
   planningStatus: z.enum(["DRAFT", "PLANNING_STATUS_UNSPECIFIED", "SUBMITTED"])
     .describe("Planning state before being submitted for evaluation")
     .optional(),
@@ -661,7 +639,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/futurereservations",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -710,6 +688,18 @@ export const model = {
       description: "Added: confidentialComputeType, params",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.04.2",
+      description: "Removed: confidentialComputeType, params",
+      upgradeAttributes: (old: Record<string, unknown>) => {
+        const {
+          confidentialComputeType: _confidentialComputeType,
+          params: _params,
+          ...rest
+        } = old;
+        return rest;
+      },
+    },
   ],
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
@@ -750,9 +740,6 @@ export const model = {
         if (g["commitmentInfo"] !== undefined) {
           body["commitmentInfo"] = g["commitmentInfo"];
         }
-        if (g["confidentialComputeType"] !== undefined) {
-          body["confidentialComputeType"] = g["confidentialComputeType"];
-        }
         if (g["deploymentType"] !== undefined) {
           body["deploymentType"] = g["deploymentType"];
         }
@@ -764,7 +751,6 @@ export const model = {
         }
         if (g["name"] !== undefined) body["name"] = g["name"];
         if (g["namePrefix"] !== undefined) body["namePrefix"] = g["namePrefix"];
-        if (g["params"] !== undefined) body["params"] = g["params"];
         if (g["planningStatus"] !== undefined) {
           body["planningStatus"] = g["planningStatus"];
         }
@@ -880,9 +866,6 @@ export const model = {
         if (g["commitmentInfo"] !== undefined) {
           body["commitmentInfo"] = g["commitmentInfo"];
         }
-        if (g["confidentialComputeType"] !== undefined) {
-          body["confidentialComputeType"] = g["confidentialComputeType"];
-        }
         if (g["deploymentType"] !== undefined) {
           body["deploymentType"] = g["deploymentType"];
         }
@@ -894,7 +877,6 @@ export const model = {
         }
         if (g["name"] !== undefined) body["name"] = g["name"];
         if (g["namePrefix"] !== undefined) body["namePrefix"] = g["namePrefix"];
-        if (g["params"] !== undefined) body["params"] = g["params"];
         if (g["planningStatus"] !== undefined) {
           body["planningStatus"] = g["planningStatus"];
         }

--- a/model/gcp/compute/extensions/models/images.ts
+++ b/model/gcp/compute/extensions/models/images.ts
@@ -154,7 +154,7 @@ const GlobalArgsSchema = z.object({
       "VIRTIO_SCSI_MULTIQUEUE",
       "WINDOWS",
     ]).describe(
-      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
     ).optional(),
   })).describe(
     "A list of features to enable on the guest operating system. Applicable only for bootable images. To see a list of available options, see theguestOSfeatures[].type parameter.",
@@ -204,7 +204,7 @@ const GlobalArgsSchema = z.object({
       "[Deprecated] This field is deprecated. An optional SHA1 checksum of the disk image before unpackaging provided by the client when the disk image is created.",
     ).optional(),
     source: z.string().describe(
-      "The full Google Cloud Storage URL or Artifact Registry path where the raw disk image archive is stored. The following are valid formats: - https://storage.googleapis.com/bucket_name/image_archive_name - https://storage.googleapis.com/bucket_name/folder_name/image_archive_name - projects/project/locations/location/repositories/repo/packages/package/versions/version_id - projects/project/locations/location/repositories/repo/packages/package/versions/version_id@dirsum_sha256:hex_value In order to create an image, you must provide the full or partial URL of one of the following: - The rawDisk.source URL - The sourceDisk URL - The sourceImage URL - The sourceSnapshot URL",
+      "The full Google Cloud Storage URL where the raw disk image archive is stored. The following are valid formats for the URL: - https://storage.googleapis.com/bucket_name/image_archive_name - https://storage.googleapis.com/bucket_name/folder_name/image_archive_name In order to create an image, you must provide the full or partial URL of one of the following: - The rawDisk.source URL - The sourceDisk URL - The sourceImage URL - The sourceSnapshot URL",
     ).optional(),
   }).describe("The parameters of the raw disk image.").optional(),
   shieldedInstanceInitialState: z.object({
@@ -458,7 +458,7 @@ const InputsSchema = z.object({
       "VIRTIO_SCSI_MULTIQUEUE",
       "WINDOWS",
     ]).describe(
-      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
     ).optional(),
   })).describe(
     "A list of features to enable on the guest operating system. Applicable only for bootable images. To see a list of available options, see theguestOSfeatures[].type parameter.",
@@ -508,7 +508,7 @@ const InputsSchema = z.object({
       "[Deprecated] This field is deprecated. An optional SHA1 checksum of the disk image before unpackaging provided by the client when the disk image is created.",
     ).optional(),
     source: z.string().describe(
-      "The full Google Cloud Storage URL or Artifact Registry path where the raw disk image archive is stored. The following are valid formats: - https://storage.googleapis.com/bucket_name/image_archive_name - https://storage.googleapis.com/bucket_name/folder_name/image_archive_name - projects/project/locations/location/repositories/repo/packages/package/versions/version_id - projects/project/locations/location/repositories/repo/packages/package/versions/version_id@dirsum_sha256:hex_value In order to create an image, you must provide the full or partial URL of one of the following: - The rawDisk.source URL - The sourceDisk URL - The sourceImage URL - The sourceSnapshot URL",
+      "The full Google Cloud Storage URL where the raw disk image archive is stored. The following are valid formats for the URL: - https://storage.googleapis.com/bucket_name/image_archive_name - https://storage.googleapis.com/bucket_name/folder_name/image_archive_name In order to create an image, you must provide the full or partial URL of one of the following: - The rawDisk.source URL - The sourceDisk URL - The sourceImage URL - The sourceSnapshot URL",
     ).optional(),
   }).describe("The parameters of the raw disk image.").optional(),
   shieldedInstanceInitialState: z.object({
@@ -617,7 +617,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/images",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -656,6 +656,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/instancegroupmanagerresizerequests.ts
+++ b/model/gcp/compute/extensions/models/instancegroupmanagerresizerequests.ts
@@ -147,7 +147,7 @@ const GlobalArgsSchema = z.object({
         "[Output Only] The array of errors encountered while processing this operation.",
       ).optional(),
     }).describe(
-      "Output only. Fatal errors encountered during the queueing or provisioning phases of the ResizeRequest that caused the transition to the FAILED state. Contrary to the last_attempt errors, this field is final and errors are never removed from here, as the ResizeRequest is not going to retry.",
+      "Output only. [Output only] Fatal errors encountered during the queueing or provisioning phases of the ResizeRequest that caused the transition to the FAILED state. Contrary to the last_attempt errors, this field is final and errors are never removed from here, as the ResizeRequest is not going to retry.",
     ).optional(),
     lastAttempt: z.object({
       error: z.object({
@@ -173,7 +173,7 @@ const GlobalArgsSchema = z.object({
     }).optional(),
   }).optional(),
   zone: z.string().describe(
-    "Output only. The URL of a zone where the resize request is located. Populated only for zonal resize requests.",
+    "Output only. [Output Only] The URL of azone where the resize request is located. Populated only for zonal resize requests.",
   ).optional(),
   instanceGroupManager: z.string().describe(
     "The name of the managed instance group to which the resize request will be added. Name should conform to RFC1035 or be a resource ID.",
@@ -189,7 +189,6 @@ const StateSchema = z.object({
   id: z.string().optional(),
   kind: z.string().optional(),
   name: z.string(),
-  region: z.string().optional(),
   requestedRunDuration: z.object({
     nanos: z.number(),
     seconds: z.string(),
@@ -262,7 +261,7 @@ const InputsSchema = z.object({
         "[Output Only] The array of errors encountered while processing this operation.",
       ).optional(),
     }).describe(
-      "Output only. Fatal errors encountered during the queueing or provisioning phases of the ResizeRequest that caused the transition to the FAILED state. Contrary to the last_attempt errors, this field is final and errors are never removed from here, as the ResizeRequest is not going to retry.",
+      "Output only. [Output only] Fatal errors encountered during the queueing or provisioning phases of the ResizeRequest that caused the transition to the FAILED state. Contrary to the last_attempt errors, this field is final and errors are never removed from here, as the ResizeRequest is not going to retry.",
     ).optional(),
     lastAttempt: z.object({
       error: z.object({
@@ -288,7 +287,7 @@ const InputsSchema = z.object({
     }).optional(),
   }).optional(),
   zone: z.string().describe(
-    "Output only. The URL of a zone where the resize request is located. Populated only for zonal resize requests.",
+    "Output only. [Output Only] The URL of azone where the resize request is located. Populated only for zonal resize requests.",
   ).optional(),
   instanceGroupManager: z.string().describe(
     "The name of the managed instance group to which the resize request will be added. Name should conform to RFC1035 or be a resource ID.",
@@ -300,7 +299,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/instancegroupmanagerresizerequests",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -339,6 +338,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/instancegroupmanagers.ts
+++ b/model/gcp/compute/extensions/models/instancegroupmanagers.ts
@@ -150,43 +150,43 @@ const GlobalArgsSchema = z.object({
   ).optional(),
   currentActions: z.object({
     abandoning: z.number().int().describe(
-      "Output only. The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
+      "Output only. [Output Only] The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
     ).optional(),
     creating: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
     ).optional(),
     creatingWithoutRetries: z.number().int().describe(
-      "Output only. The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
+      "Output only. [Output Only] The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
     ).optional(),
     deleting: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
     ).optional(),
     none: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are running and have no scheduled actions.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are running and have no scheduled actions.",
     ).optional(),
     recreating: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
     ).optional(),
     refreshing: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
     ).optional(),
     restarting: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
     ).optional(),
     resuming: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
     ).optional(),
     starting: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
     ).optional(),
     stopping: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
     ).optional(),
     suspending: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
     ).optional(),
     verifying: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
     ).optional(),
   }).optional(),
   description: z.string().describe("An optional description of this resource.")
@@ -297,15 +297,15 @@ const GlobalArgsSchema = z.object({
   status: z.object({
     allInstancesConfig: z.object({
       currentRevision: z.string().describe(
-        "Output only. Current all-instances configuration revision. This value is in RFC3339 text format.",
+        "Output only. [Output Only] Current all-instances configuration revision. This value is in RFC3339 text format.",
       ).optional(),
       effective: z.boolean().describe(
-        "Output only. A bit indicating whether this configuration has been applied to all managed instances in the group.",
+        "Output only. [Output Only] A bit indicating whether this configuration has been applied to all managed instances in the group.",
       ).optional(),
     }).optional(),
     appliedAcceleratorTopologies: z.array(z.object({
       acceleratorTopology: z.string().describe(
-        'Output only. Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
+        'Output only. [Output Only] Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
       ).optional(),
       state: z.enum([
         "ACTIVATING",
@@ -314,27 +314,29 @@ const GlobalArgsSchema = z.object({
         "FAILED",
         "INCOMPLETE",
         "REACTIVATING",
-      ]).describe("Output only. The state of the accelerator topology.")
-        .optional(),
+      ]).describe(
+        "Output only. [Output Only] The state of the accelerator topology.",
+      ).optional(),
       stateDetails: z.object({
         error: z.object({
           errors: z.unknown().describe(
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
-        }).describe("Output only. Encountered errors.").optional(),
+        }).describe("Output only. [Output Only] Encountered errors.")
+          .optional(),
         timestamp: z.string().describe(
-          "Output only. Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
+          "Output only. [Output Only] Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
         ).optional(),
       }).optional(),
     })).describe(
-      "Output only. The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
+      "Output only. [Output Only] The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
     ).optional(),
     autoscaler: z.string().describe(
-      "Output only. The URL of theAutoscaler that targets this instance group manager.",
+      "Output only. [Output Only] The URL of theAutoscaler that targets this instance group manager.",
     ).optional(),
     bulkInstanceOperation: z.object({
       inProgress: z.boolean().describe(
-        "Output only. Informs whether bulk instance operation is in progress.",
+        "Output only. [Output Only] Informs whether bulk instance operation is in progress.",
       ).optional(),
       lastProgressCheck: z.object({
         error: z.object({
@@ -342,64 +344,21 @@ const GlobalArgsSchema = z.object({
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
         }).describe(
-          "Output only. Errors encountered during bulk instance operation.",
+          "Output only. [Output Only] Errors encountered during bulk instance operation.",
         ).optional(),
         timestamp: z.string().describe(
-          "Output only. Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
+          "Output only. [Output Only] Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
         ).optional(),
       }).optional(),
     }).describe(
       "Bulk instance operation is the creation of VMs in a MIG when the targetSizePolicy.mode is set to BULK.",
     ).optional(),
-    currentInstanceStatuses: z.object({
-      deprovisioning: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have DEPROVISIONING status.",
-      ).optional(),
-      nonExistent: z.number().int().describe(
-        "Output only. The number of instances that have not been created yet or have been deleted. Includes only instances that would be shown in the listManagedInstances method and not all instances that have been deleted in the lifetime of the MIG. Does not include FlexStart instances that are waiting for the resources availability, they are considered as 'pending'.",
-      ).optional(),
-      pending: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have PENDING status, that is FlexStart instances that are waiting for resources. Instances that do not exist because of the other reasons are counted as 'non_existent'.",
-      ).optional(),
-      pendingStop: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have PENDING_STOP status.",
-      ).optional(),
-      provisioning: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have PROVISIONING status.",
-      ).optional(),
-      repairing: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have REPAIRING status.",
-      ).optional(),
-      running: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have RUNNING status.",
-      ).optional(),
-      staging: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have STAGING status.",
-      ).optional(),
-      stopped: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have STOPPED status.",
-      ).optional(),
-      stopping: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have STOPPING status.",
-      ).optional(),
-      suspended: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have SUSPENDED status.",
-      ).optional(),
-      suspending: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have SUSPENDING status.",
-      ).optional(),
-      terminated: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have TERMINATED status.",
-      ).optional(),
-    }).describe(
-      "The list of instance statuses and the number of instances in this managed instance group that have the status. For more information about how to interpret each status check the instance lifecycle documentation. Currently only shown for TPU MIGs.",
-    ).optional(),
     isStable: z.boolean().describe(
-      "Output only. A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
+      "Output only. [Output Only] A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
     ).optional(),
     stateful: z.object({
       hasStatefulConfig: z.boolean().describe(
-        "Output only. A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
+        "Output only. [Output Only] A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
       ).optional(),
       perInstanceConfigs: z.object({
         allEffective: z.boolean().describe(
@@ -409,7 +368,7 @@ const GlobalArgsSchema = z.object({
     }).optional(),
     versionTarget: z.object({
       isReached: z.boolean().describe(
-        "Output only. A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
+        "Output only. [Output Only] A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
       ).optional(),
     }).optional(),
   }).optional(),
@@ -502,7 +461,7 @@ const GlobalArgsSchema = z.object({
     "Specifies the instance templates used by this managed instance group to create instances. Each version is defined by an instanceTemplate and aname. Every version can appear at most once per instance group. This field overrides the top-level instanceTemplate field. Read more about therelationships between these fields. Exactly one version must leave thetargetSize field unset. That version will be applied to all remaining instances. For more information, read aboutcanary updates.",
   ).optional(),
   zone: z.string().describe(
-    "Output only. The URL of azone where the managed instance group is located (for zonal resources).",
+    "Output only. [Output Only] The URL of azone where the managed instance group is located (for zonal resources).",
   ).optional(),
   requestId: z.string().describe(
     "An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).",
@@ -606,21 +565,6 @@ const StateSchema = z.object({
         timestamp: z.string(),
       }),
     }),
-    currentInstanceStatuses: z.object({
-      deprovisioning: z.number(),
-      nonExistent: z.number(),
-      pending: z.number(),
-      pendingStop: z.number(),
-      provisioning: z.number(),
-      repairing: z.number(),
-      running: z.number(),
-      staging: z.number(),
-      stopped: z.number(),
-      stopping: z.number(),
-      suspended: z.number(),
-      suspending: z.number(),
-      terminated: z.number(),
-    }),
     isStable: z.boolean(),
     stateful: z.object({
       hasStatefulConfig: z.boolean(),
@@ -698,43 +642,43 @@ const InputsSchema = z.object({
   ).optional(),
   currentActions: z.object({
     abandoning: z.number().int().describe(
-      "Output only. The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
+      "Output only. [Output Only] The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
     ).optional(),
     creating: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
     ).optional(),
     creatingWithoutRetries: z.number().int().describe(
-      "Output only. The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
+      "Output only. [Output Only] The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
     ).optional(),
     deleting: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
     ).optional(),
     none: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are running and have no scheduled actions.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are running and have no scheduled actions.",
     ).optional(),
     recreating: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
     ).optional(),
     refreshing: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
     ).optional(),
     restarting: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
     ).optional(),
     resuming: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
     ).optional(),
     starting: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
     ).optional(),
     stopping: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
     ).optional(),
     suspending: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
     ).optional(),
     verifying: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
     ).optional(),
   }).optional(),
   description: z.string().describe("An optional description of this resource.")
@@ -845,15 +789,15 @@ const InputsSchema = z.object({
   status: z.object({
     allInstancesConfig: z.object({
       currentRevision: z.string().describe(
-        "Output only. Current all-instances configuration revision. This value is in RFC3339 text format.",
+        "Output only. [Output Only] Current all-instances configuration revision. This value is in RFC3339 text format.",
       ).optional(),
       effective: z.boolean().describe(
-        "Output only. A bit indicating whether this configuration has been applied to all managed instances in the group.",
+        "Output only. [Output Only] A bit indicating whether this configuration has been applied to all managed instances in the group.",
       ).optional(),
     }).optional(),
     appliedAcceleratorTopologies: z.array(z.object({
       acceleratorTopology: z.string().describe(
-        'Output only. Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
+        'Output only. [Output Only] Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
       ).optional(),
       state: z.enum([
         "ACTIVATING",
@@ -862,27 +806,29 @@ const InputsSchema = z.object({
         "FAILED",
         "INCOMPLETE",
         "REACTIVATING",
-      ]).describe("Output only. The state of the accelerator topology.")
-        .optional(),
+      ]).describe(
+        "Output only. [Output Only] The state of the accelerator topology.",
+      ).optional(),
       stateDetails: z.object({
         error: z.object({
           errors: z.unknown().describe(
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
-        }).describe("Output only. Encountered errors.").optional(),
+        }).describe("Output only. [Output Only] Encountered errors.")
+          .optional(),
         timestamp: z.string().describe(
-          "Output only. Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
+          "Output only. [Output Only] Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
         ).optional(),
       }).optional(),
     })).describe(
-      "Output only. The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
+      "Output only. [Output Only] The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
     ).optional(),
     autoscaler: z.string().describe(
-      "Output only. The URL of theAutoscaler that targets this instance group manager.",
+      "Output only. [Output Only] The URL of theAutoscaler that targets this instance group manager.",
     ).optional(),
     bulkInstanceOperation: z.object({
       inProgress: z.boolean().describe(
-        "Output only. Informs whether bulk instance operation is in progress.",
+        "Output only. [Output Only] Informs whether bulk instance operation is in progress.",
       ).optional(),
       lastProgressCheck: z.object({
         error: z.object({
@@ -890,64 +836,21 @@ const InputsSchema = z.object({
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
         }).describe(
-          "Output only. Errors encountered during bulk instance operation.",
+          "Output only. [Output Only] Errors encountered during bulk instance operation.",
         ).optional(),
         timestamp: z.string().describe(
-          "Output only. Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
+          "Output only. [Output Only] Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
         ).optional(),
       }).optional(),
     }).describe(
       "Bulk instance operation is the creation of VMs in a MIG when the targetSizePolicy.mode is set to BULK.",
     ).optional(),
-    currentInstanceStatuses: z.object({
-      deprovisioning: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have DEPROVISIONING status.",
-      ).optional(),
-      nonExistent: z.number().int().describe(
-        "Output only. The number of instances that have not been created yet or have been deleted. Includes only instances that would be shown in the listManagedInstances method and not all instances that have been deleted in the lifetime of the MIG. Does not include FlexStart instances that are waiting for the resources availability, they are considered as 'pending'.",
-      ).optional(),
-      pending: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have PENDING status, that is FlexStart instances that are waiting for resources. Instances that do not exist because of the other reasons are counted as 'non_existent'.",
-      ).optional(),
-      pendingStop: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have PENDING_STOP status.",
-      ).optional(),
-      provisioning: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have PROVISIONING status.",
-      ).optional(),
-      repairing: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have REPAIRING status.",
-      ).optional(),
-      running: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have RUNNING status.",
-      ).optional(),
-      staging: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have STAGING status.",
-      ).optional(),
-      stopped: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have STOPPED status.",
-      ).optional(),
-      stopping: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have STOPPING status.",
-      ).optional(),
-      suspended: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have SUSPENDED status.",
-      ).optional(),
-      suspending: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have SUSPENDING status.",
-      ).optional(),
-      terminated: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have TERMINATED status.",
-      ).optional(),
-    }).describe(
-      "The list of instance statuses and the number of instances in this managed instance group that have the status. For more information about how to interpret each status check the instance lifecycle documentation. Currently only shown for TPU MIGs.",
-    ).optional(),
     isStable: z.boolean().describe(
-      "Output only. A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
+      "Output only. [Output Only] A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
     ).optional(),
     stateful: z.object({
       hasStatefulConfig: z.boolean().describe(
-        "Output only. A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
+        "Output only. [Output Only] A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
       ).optional(),
       perInstanceConfigs: z.object({
         allEffective: z.boolean().describe(
@@ -957,7 +860,7 @@ const InputsSchema = z.object({
     }).optional(),
     versionTarget: z.object({
       isReached: z.boolean().describe(
-        "Output only. A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
+        "Output only. [Output Only] A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
       ).optional(),
     }).optional(),
   }).optional(),
@@ -1050,7 +953,7 @@ const InputsSchema = z.object({
     "Specifies the instance templates used by this managed instance group to create instances. Each version is defined by an instanceTemplate and aname. Every version can appear at most once per instance group. This field overrides the top-level instanceTemplate field. Read more about therelationships between these fields. Exactly one version must leave thetargetSize field unset. That version will be applied to all remaining instances. For more information, read aboutcanary updates.",
   ).optional(),
   zone: z.string().describe(
-    "Output only. The URL of azone where the managed instance group is located (for zonal resources).",
+    "Output only. [Output Only] The URL of azone where the managed instance group is located (for zonal resources).",
   ).optional(),
   requestId: z.string().describe(
     "An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).",
@@ -1059,7 +962,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/instancegroupmanagers",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1098,6 +1001,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/instances.ts
+++ b/model/gcp/compute/extensions/models/instances.ts
@@ -236,7 +236,7 @@ const GlobalArgsSchema = z.object({
         "VIRTIO_SCSI_MULTIQUEUE",
         "WINDOWS",
       ]).describe(
-        "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+        "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
       ).optional(),
     })).describe(
       "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -610,9 +610,6 @@ const GlobalArgsSchema = z.object({
     ).optional(),
     queueCount: z.number().int().describe(
       "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
-    ).optional(),
-    serviceClassId: z.string().describe(
-      "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
     ).optional(),
     stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
       "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
@@ -992,7 +989,6 @@ const StateSchema = z.object({
     nicType: z.string(),
     parentNicName: z.string(),
     queueCount: z.number(),
-    serviceClassId: z.string(),
     stackType: z.string(),
     subnetwork: z.string(),
     vlan: z.number(),
@@ -1220,7 +1216,7 @@ const InputsSchema = z.object({
         "VIRTIO_SCSI_MULTIQUEUE",
         "WINDOWS",
       ]).describe(
-        "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+        "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
       ).optional(),
     })).describe(
       "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -1595,9 +1591,6 @@ const InputsSchema = z.object({
     queueCount: z.number().int().describe(
       "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
     ).optional(),
-    serviceClassId: z.string().describe(
-      "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
-    ).optional(),
     stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
       "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
     ).optional(),
@@ -1805,7 +1798,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/instances",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1847,6 +1840,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -2343,7 +2341,6 @@ export const model = {
         nicType: z.any().optional(),
         parentNicName: z.any().optional(),
         queueCount: z.any().optional(),
-        serviceClassId: z.any().optional(),
         stackType: z.any().optional(),
         subnetwork: z.any().optional(),
         vlan: z.any().optional(),
@@ -2410,9 +2407,6 @@ export const model = {
         }
         if (args["queueCount"] !== undefined) {
           body["queueCount"] = args["queueCount"];
-        }
-        if (args["serviceClassId"] !== undefined) {
-          body["serviceClassId"] = args["serviceClassId"];
         }
         if (args["stackType"] !== undefined) {
           body["stackType"] = args["stackType"];
@@ -4275,7 +4269,6 @@ export const model = {
         nicType: z.any().optional(),
         parentNicName: z.any().optional(),
         queueCount: z.any().optional(),
-        serviceClassId: z.any().optional(),
         stackType: z.any().optional(),
         subnetwork: z.any().optional(),
         vlan: z.any().optional(),
@@ -4344,9 +4337,6 @@ export const model = {
         }
         if (args["queueCount"] !== undefined) {
           body["queueCount"] = args["queueCount"];
-        }
-        if (args["serviceClassId"] !== undefined) {
-          body["serviceClassId"] = args["serviceClassId"];
         }
         if (args["stackType"] !== undefined) {
           body["stackType"] = args["stackType"];

--- a/model/gcp/compute/extensions/models/instancetemplates.ts
+++ b/model/gcp/compute/extensions/models/instancetemplates.ts
@@ -166,7 +166,7 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -480,9 +480,6 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
-      ).optional(),
-      serviceClassId: z.string().describe(
-        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
       ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
@@ -829,7 +826,6 @@ const StateSchema = z.object({
       nicType: z.string(),
       parentNicName: z.string(),
       queueCount: z.number(),
-      serviceClassId: z.string(),
       stackType: z.string(),
       subnetwork: z.string(),
       vlan: z.number(),
@@ -998,7 +994,7 @@ const InputsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -1313,9 +1309,6 @@ const InputsSchema = z.object({
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
       ).optional(),
-      serviceClassId: z.string().describe(
-        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
-      ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
       ).optional(),
@@ -1515,7 +1508,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/instancetemplates",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1554,6 +1547,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/instantsnapshots.ts
+++ b/model/gcp/compute/extensions/models/instantsnapshots.ts
@@ -148,8 +148,6 @@ const StateSchema = z.object({
   selfLinkWithId: z.string().optional(),
   sourceDisk: z.string().optional(),
   sourceDiskId: z.string().optional(),
-  sourceInstantSnapshotGroup: z.string().optional(),
-  sourceInstantSnapshotGroupId: z.string().optional(),
   status: z.string().optional(),
   zone: z.string().optional(),
 }).passthrough();
@@ -193,7 +191,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/instantsnapshots",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -222,6 +220,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/machineimages.ts
+++ b/model/gcp/compute/extensions/models/machineimages.ts
@@ -168,7 +168,7 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -483,9 +483,6 @@ const GlobalArgsSchema = z.object({
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
       ).optional(),
-      serviceClassId: z.string().describe(
-        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
-      ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
       ).optional(),
@@ -750,7 +747,7 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -956,9 +953,6 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
-      ).optional(),
-      serviceClassId: z.string().describe(
-        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
       ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
@@ -1234,7 +1228,6 @@ const StateSchema = z.object({
       nicType: z.string(),
       parentNicName: z.string(),
       queueCount: z.number(),
-      serviceClassId: z.string(),
       stackType: z.string(),
       subnetwork: z.string(),
       vlan: z.number(),
@@ -1421,7 +1414,6 @@ const StateSchema = z.object({
       nicType: z.string(),
       parentNicName: z.string(),
       queueCount: z.number(),
-      serviceClassId: z.string(),
       stackType: z.string(),
       subnetwork: z.string(),
       vlan: z.number(),
@@ -1562,7 +1554,7 @@ const InputsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -1877,9 +1869,6 @@ const InputsSchema = z.object({
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
       ).optional(),
-      serviceClassId: z.string().describe(
-        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
-      ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
       ).optional(),
@@ -2144,7 +2133,7 @@ const InputsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -2351,9 +2340,6 @@ const InputsSchema = z.object({
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
       ).optional(),
-      serviceClassId: z.string().describe(
-        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
-      ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
       ).optional(),
@@ -2483,7 +2469,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/machineimages",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -2522,6 +2508,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/networkattachments.ts
+++ b/model/gcp/compute/extensions/models/networkattachments.ts
@@ -158,7 +158,6 @@ const StateSchema = z.object({
     ipv6Address: z.string(),
     projectIdOrNum: z.string(),
     secondaryIpCidrRanges: z.array(z.string()),
-    serviceClassId: z.string(),
     status: z.string(),
     subnetwork: z.string(),
     subnetworkCidrRange: z.string(),
@@ -213,7 +212,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/networkattachments",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -252,6 +251,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/regionbackendservices.ts
+++ b/model/gcp/compute/extensions/models/regionbackendservices.ts
@@ -130,7 +130,6 @@ const GlobalArgsSchema = z.object({
     balancingMode: z.enum([
       "CONNECTION",
       "CUSTOM_METRICS",
-      "IN_FLIGHT",
       "RATE",
       "UTILIZATION",
     ]).describe(
@@ -170,15 +169,6 @@ const GlobalArgsSchema = z.object({
     maxConnectionsPerInstance: z.number().int().describe(
       "Defines a target maximum number of simultaneous connections. For usage guidelines, seeConnection balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isRATE.",
     ).optional(),
-    maxInFlightRequests: z.number().int().describe(
-      "Defines a maximum number of in-flight requests for the whole NEG or instance group. Not available if backend's balancingMode isRATE or CONNECTION.",
-    ).optional(),
-    maxInFlightRequestsPerEndpoint: z.number().int().describe(
-      "Defines a maximum number of in-flight requests for a single endpoint. Not available if backend's balancingMode is RATE or CONNECTION.",
-    ).optional(),
-    maxInFlightRequestsPerInstance: z.number().int().describe(
-      "Defines a maximum number of in-flight requests for a single VM. Not available if backend's balancingMode is RATE or CONNECTION.",
-    ).optional(),
     maxRate: z.number().int().describe(
       "Defines a maximum number of HTTP requests per second (RPS). For usage guidelines, seeRate balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isCONNECTION.",
     ).optional(),
@@ -202,8 +192,6 @@ const GlobalArgsSchema = z.object({
       .describe(
         "This field indicates whether this backend should be fully utilized before sending traffic to backends with default preference. The possible values are: - PREFERRED: Backends with this preference level will be filled up to their capacity limits first, based on RTT. - DEFAULT: If preferred backends don't have enough capacity, backends in this layer would be used and traffic would be assigned based on the load balancing algorithm you use. This is the default",
       ).optional(),
-    trafficDuration: z.enum(["LONG", "SHORT", "TRAFFIC_DURATION_UNSPECIFIED"])
-      .optional(),
   })).describe("The list of backends that serve this BackendService.")
     .optional(),
   cdnPolicy: z.object({
@@ -502,7 +490,7 @@ const GlobalArgsSchema = z.object({
     "WEIGHTED_MAGLEV",
     "WEIGHTED_ROUND_ROBIN",
   ]).describe(
-    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
+    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
   ).optional(),
   logConfig: z.object({
     enable: z.boolean().describe(
@@ -745,9 +733,6 @@ const StateSchema = z.object({
     maxConnections: z.number(),
     maxConnectionsPerEndpoint: z.number(),
     maxConnectionsPerInstance: z.number(),
-    maxInFlightRequests: z.number(),
-    maxInFlightRequestsPerEndpoint: z.number(),
-    maxInFlightRequestsPerInstance: z.number(),
     maxRate: z.number(),
     maxRatePerEndpoint: z.number(),
     maxRatePerInstance: z.number(),
@@ -756,7 +741,6 @@ const StateSchema = z.object({
       resourceUri: z.string(),
     }),
     preference: z.string(),
-    trafficDuration: z.string(),
   })).optional(),
   cdnPolicy: z.object({
     bypassCacheOnRequestHeaders: z.array(z.object({
@@ -960,7 +944,6 @@ const InputsSchema = z.object({
     balancingMode: z.enum([
       "CONNECTION",
       "CUSTOM_METRICS",
-      "IN_FLIGHT",
       "RATE",
       "UTILIZATION",
     ]).describe(
@@ -1000,15 +983,6 @@ const InputsSchema = z.object({
     maxConnectionsPerInstance: z.number().int().describe(
       "Defines a target maximum number of simultaneous connections. For usage guidelines, seeConnection balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isRATE.",
     ).optional(),
-    maxInFlightRequests: z.number().int().describe(
-      "Defines a maximum number of in-flight requests for the whole NEG or instance group. Not available if backend's balancingMode isRATE or CONNECTION.",
-    ).optional(),
-    maxInFlightRequestsPerEndpoint: z.number().int().describe(
-      "Defines a maximum number of in-flight requests for a single endpoint. Not available if backend's balancingMode is RATE or CONNECTION.",
-    ).optional(),
-    maxInFlightRequestsPerInstance: z.number().int().describe(
-      "Defines a maximum number of in-flight requests for a single VM. Not available if backend's balancingMode is RATE or CONNECTION.",
-    ).optional(),
     maxRate: z.number().int().describe(
       "Defines a maximum number of HTTP requests per second (RPS). For usage guidelines, seeRate balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isCONNECTION.",
     ).optional(),
@@ -1032,8 +1006,6 @@ const InputsSchema = z.object({
       .describe(
         "This field indicates whether this backend should be fully utilized before sending traffic to backends with default preference. The possible values are: - PREFERRED: Backends with this preference level will be filled up to their capacity limits first, based on RTT. - DEFAULT: If preferred backends don't have enough capacity, backends in this layer would be used and traffic would be assigned based on the load balancing algorithm you use. This is the default",
       ).optional(),
-    trafficDuration: z.enum(["LONG", "SHORT", "TRAFFIC_DURATION_UNSPECIFIED"])
-      .optional(),
   })).describe("The list of backends that serve this BackendService.")
     .optional(),
   cdnPolicy: z.object({
@@ -1332,7 +1304,7 @@ const InputsSchema = z.object({
     "WEIGHTED_MAGLEV",
     "WEIGHTED_ROUND_ROBIN",
   ]).describe(
-    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
+    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
   ).optional(),
   logConfig: z.object({
     enable: z.boolean().describe(
@@ -1561,7 +1533,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regionbackendservices",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1600,6 +1572,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/regioncommitments.ts
+++ b/model/gcp/compute/extensions/models/regioncommitments.ts
@@ -124,11 +124,6 @@ const GlobalArgsSchema = z.object({
     .describe(
       "Name of the commitment. You must specify a name when you purchase the commitment. The name must be 1-63 characters long, and comply withRFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.",
     ).optional(),
-  params: z.object({
-    resourceManagerTags: z.record(z.string(), z.string()).describe(
-      "Input only. Resource manager tags to be bound to the commitment. Tag keys and values have the same definition as resource manager tags. Keys and values can be either in numeric format, such as `tagKeys/{tag_key_id}` and `tagValues/{tag_value_id}` or in namespaced format such as `{org_id|project_id}/{tag_key_short_name}` and `{tag_value_short_name}`. The field is ignored (both PUT & PATCH) when empty.",
-    ).optional(),
-  }).describe("Additional commitment params.").optional(),
   plan: z.enum(["INVALID", "THIRTY_SIX_MONTH", "TWELVE_MONTH"]).describe(
     "The minimum time duration that you commit to purchasing resources. The plan that you choose determines the preset term length of the commitment (which is 1 year or 3 years) and affects the discount rate that you receive for your resources. Committing to a longer time duration typically gives you a higher discount rate. The supported values for this field are TWELVE_MONTH (1 year), andTHIRTY_SIX_MONTH (3 years).",
   ).optional(),
@@ -178,10 +173,6 @@ const GlobalArgsSchema = z.object({
     commitment: z.string().describe(
       "Output only. [Output Only] Full or partial URL to a parent commitment. This field displays for reservations that are tied to a commitment.",
     ).optional(),
-    confidentialComputeType: z.enum([
-      "CONFIDENTIAL_COMPUTE_TYPE_TDX",
-      "CONFIDENTIAL_COMPUTE_TYPE_UNSPECIFIED",
-    ]).optional(),
     creationTimestamp: z.string().describe(
       "Output only. [Output Only] Creation timestamp inRFC3339 text format.",
     ).optional(),
@@ -481,9 +472,6 @@ const StateSchema = z.object({
   }).optional(),
   mergeSourceCommitments: z.array(z.string()).optional(),
   name: z.string(),
-  params: z.object({
-    resourceManagerTags: z.record(z.string(), z.unknown()),
-  }).optional(),
   plan: z.string().optional(),
   region: z.string().optional(),
   reservations: z.array(z.object({
@@ -501,7 +489,6 @@ const StateSchema = z.object({
       workloadType: z.string(),
     }),
     commitment: z.string(),
-    confidentialComputeType: z.string(),
     creationTimestamp: z.string(),
     deleteAfterDuration: z.object({
       nanos: z.number(),
@@ -625,11 +612,6 @@ const InputsSchema = z.object({
     .describe(
       "Name of the commitment. You must specify a name when you purchase the commitment. The name must be 1-63 characters long, and comply withRFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.",
     ).optional(),
-  params: z.object({
-    resourceManagerTags: z.record(z.string(), z.string()).describe(
-      "Input only. Resource manager tags to be bound to the commitment. Tag keys and values have the same definition as resource manager tags. Keys and values can be either in numeric format, such as `tagKeys/{tag_key_id}` and `tagValues/{tag_value_id}` or in namespaced format such as `{org_id|project_id}/{tag_key_short_name}` and `{tag_value_short_name}`. The field is ignored (both PUT & PATCH) when empty.",
-    ).optional(),
-  }).describe("Additional commitment params.").optional(),
   plan: z.enum(["INVALID", "THIRTY_SIX_MONTH", "TWELVE_MONTH"]).describe(
     "The minimum time duration that you commit to purchasing resources. The plan that you choose determines the preset term length of the commitment (which is 1 year or 3 years) and affects the discount rate that you receive for your resources. Committing to a longer time duration typically gives you a higher discount rate. The supported values for this field are TWELVE_MONTH (1 year), andTHIRTY_SIX_MONTH (3 years).",
   ).optional(),
@@ -679,10 +661,6 @@ const InputsSchema = z.object({
     commitment: z.string().describe(
       "Output only. [Output Only] Full or partial URL to a parent commitment. This field displays for reservations that are tied to a commitment.",
     ).optional(),
-    confidentialComputeType: z.enum([
-      "CONFIDENTIAL_COMPUTE_TYPE_TDX",
-      "CONFIDENTIAL_COMPUTE_TYPE_UNSPECIFIED",
-    ]).optional(),
     creationTimestamp: z.string().describe(
       "Output only. [Output Only] Creation timestamp inRFC3339 text format.",
     ).optional(),
@@ -967,7 +945,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regioncommitments",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1011,6 +989,14 @@ export const model = {
       toVersion: "2026.04.04.1",
       description: "Added: params",
       upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
+      description: "Removed: params",
+      upgradeAttributes: (old: Record<string, unknown>) => {
+        const { params: _params, ...rest } = old;
+        return rest;
+      },
     },
   ],
   globalArguments: GlobalArgsSchema,
@@ -1056,7 +1042,6 @@ export const model = {
           body["mergeSourceCommitments"] = g["mergeSourceCommitments"];
         }
         if (g["name"] !== undefined) body["name"] = g["name"];
-        if (g["params"] !== undefined) body["params"] = g["params"];
         if (g["plan"] !== undefined) body["plan"] = g["plan"];
         if (g["reservations"] !== undefined) {
           body["reservations"] = g["reservations"];
@@ -1169,7 +1154,6 @@ export const model = {
           body["mergeSourceCommitments"] = g["mergeSourceCommitments"];
         }
         if (g["name"] !== undefined) body["name"] = g["name"];
-        if (g["params"] !== undefined) body["params"] = g["params"];
         if (g["plan"] !== undefined) body["plan"] = g["plan"];
         if (g["reservations"] !== undefined) {
           body["reservations"] = g["reservations"];

--- a/model/gcp/compute/extensions/models/regioncompositehealthchecks.ts
+++ b/model/gcp/compute/extensions/models/regioncompositehealthchecks.ts
@@ -190,7 +190,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regioncompositehealthchecks",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -229,6 +229,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -465,48 +470,6 @@ export const model = {
           }
           throw error;
         }
-      },
-    },
-    get_health: {
-      description: "get health",
-      arguments: z.object({}),
-      execute: async (_args: Record<string, unknown>, context: any) => {
-        const g = context.globalArgs;
-        const projectId = await getProjectId();
-        const params: Record<string, string> = { project: projectId };
-        if (g["region"] !== undefined) params["region"] = String(g["region"]);
-        const content = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          (g.name?.toString() ?? "current").replace(/[\/\\]/g, "_").replace(
-            /\.\./g,
-            "_",
-          ).replace(/\0/g, ""),
-        );
-        if (!content) {
-          throw new Error("No existing state found - run create or get first");
-        }
-        const existing = JSON.parse(new TextDecoder().decode(content));
-        params["compositeHealthCheck"] = existing["name"]?.toString() ??
-          g["name"]?.toString() ?? "";
-        const result = await createResource(
-          BASE_URL,
-          {
-            "id": "compute.regionCompositeHealthChecks.getHealth",
-            "path":
-              "projects/{project}/regions/{region}/compositeHealthChecks/{compositeHealthCheck}/getHealth",
-            "httpMethod": "GET",
-            "parameterOrder": ["project", "region", "compositeHealthCheck"],
-            "parameters": {
-              "compositeHealthCheck": { "location": "path", "required": true },
-              "project": { "location": "path", "required": true },
-              "region": { "location": "path", "required": true },
-            },
-          },
-          params,
-          {},
-        );
-        return { result };
       },
     },
   },

--- a/model/gcp/compute/extensions/models/regiondisks.ts
+++ b/model/gcp/compute/extensions/models/regiondisks.ts
@@ -191,7 +191,7 @@ const GlobalArgsSchema = z.object({
       "VIRTIO_SCSI_MULTIQUEUE",
       "WINDOWS",
     ]).describe(
-      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
     ).optional(),
   })).describe(
     "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -477,7 +477,7 @@ const InputsSchema = z.object({
       "VIRTIO_SCSI_MULTIQUEUE",
       "WINDOWS",
     ]).describe(
-      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
     ).optional(),
   })).describe(
     "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -615,7 +615,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regiondisks",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -654,6 +654,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -1086,8 +1091,6 @@ export const model = {
     bulk_insert: {
       description: "bulk insert",
       arguments: z.object({
-        instantSnapshotGroupParameters: z.any().optional(),
-        snapshotGroupParameters: z.any().optional(),
         sourceConsistencyGroupPolicy: z.any().optional(),
       }),
       execute: async (args: Record<string, unknown>, context: any) => {
@@ -1096,13 +1099,6 @@ export const model = {
         const params: Record<string, string> = { project: projectId };
         if (g["region"] !== undefined) params["region"] = String(g["region"]);
         const body: Record<string, unknown> = {};
-        if (args["instantSnapshotGroupParameters"] !== undefined) {
-          body["instantSnapshotGroupParameters"] =
-            args["instantSnapshotGroupParameters"];
-        }
-        if (args["snapshotGroupParameters"] !== undefined) {
-          body["snapshotGroupParameters"] = args["snapshotGroupParameters"];
-        }
         if (args["sourceConsistencyGroupPolicy"] !== undefined) {
           body["sourceConsistencyGroupPolicy"] =
             args["sourceConsistencyGroupPolicy"];
@@ -1149,13 +1145,10 @@ export const model = {
         locationHint: z.any().optional(),
         name: z.any().optional(),
         params: z.any().optional(),
-        region: z.any().optional(),
         satisfiesPzi: z.any().optional(),
         satisfiesPzs: z.any().optional(),
         selfLink: z.any().optional(),
         snapshotEncryptionKey: z.any().optional(),
-        snapshotGroupId: z.any().optional(),
-        snapshotGroupName: z.any().optional(),
         snapshotType: z.any().optional(),
         sourceDisk: z.any().optional(),
         sourceDiskEncryptionKey: z.any().optional(),
@@ -1239,7 +1232,6 @@ export const model = {
         }
         if (args["name"] !== undefined) body["name"] = args["name"];
         if (args["params"] !== undefined) body["params"] = args["params"];
-        if (args["region"] !== undefined) body["region"] = args["region"];
         if (args["satisfiesPzi"] !== undefined) {
           body["satisfiesPzi"] = args["satisfiesPzi"];
         }
@@ -1249,12 +1241,6 @@ export const model = {
         if (args["selfLink"] !== undefined) body["selfLink"] = args["selfLink"];
         if (args["snapshotEncryptionKey"] !== undefined) {
           body["snapshotEncryptionKey"] = args["snapshotEncryptionKey"];
-        }
-        if (args["snapshotGroupId"] !== undefined) {
-          body["snapshotGroupId"] = args["snapshotGroupId"];
-        }
-        if (args["snapshotGroupName"] !== undefined) {
-          body["snapshotGroupName"] = args["snapshotGroupName"];
         }
         if (args["snapshotType"] !== undefined) {
           body["snapshotType"] = args["snapshotType"];
@@ -1533,55 +1519,6 @@ export const model = {
             "httpMethod": "POST",
             "parameterOrder": ["project", "region"],
             "parameters": {
-              "project": { "location": "path", "required": true },
-              "region": { "location": "path", "required": true },
-              "requestId": { "location": "query" },
-            },
-          },
-          params,
-          body,
-        );
-        return { result };
-      },
-    },
-    update_kms_key: {
-      description: "update kms key",
-      arguments: z.object({
-        kmsKeyName: z.any().optional(),
-      }),
-      execute: async (args: Record<string, unknown>, context: any) => {
-        const g = context.globalArgs;
-        const projectId = await getProjectId();
-        const params: Record<string, string> = { project: projectId };
-        if (g["region"] !== undefined) params["region"] = String(g["region"]);
-        const content = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          (g.name?.toString() ?? "current").replace(/[\/\\]/g, "_").replace(
-            /\.\./g,
-            "_",
-          ).replace(/\0/g, ""),
-        );
-        if (!content) {
-          throw new Error("No existing state found - run create or get first");
-        }
-        const existing = JSON.parse(new TextDecoder().decode(content));
-        params["disk"] = existing["name"]?.toString() ??
-          g["name"]?.toString() ?? "";
-        const body: Record<string, unknown> = {};
-        if (args["kmsKeyName"] !== undefined) {
-          body["kmsKeyName"] = args["kmsKeyName"];
-        }
-        const result = await createResource(
-          BASE_URL,
-          {
-            "id": "compute.regionDisks.updateKmsKey",
-            "path":
-              "projects/{project}/regions/{region}/disks/{disk}/updateKmsKey",
-            "httpMethod": "POST",
-            "parameterOrder": ["project", "region", "disk"],
-            "parameters": {
-              "disk": { "location": "path", "required": true },
               "project": { "location": "path", "required": true },
               "region": { "location": "path", "required": true },
               "requestId": { "location": "query" },

--- a/model/gcp/compute/extensions/models/regionhealthsources.ts
+++ b/model/gcp/compute/extensions/models/regionhealthsources.ts
@@ -194,7 +194,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regionhealthsources",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -233,6 +233,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -461,48 +466,6 @@ export const model = {
           }
           throw error;
         }
-      },
-    },
-    get_health: {
-      description: "get health",
-      arguments: z.object({}),
-      execute: async (_args: Record<string, unknown>, context: any) => {
-        const g = context.globalArgs;
-        const projectId = await getProjectId();
-        const params: Record<string, string> = { project: projectId };
-        if (g["region"] !== undefined) params["region"] = String(g["region"]);
-        const content = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          (g.name?.toString() ?? "current").replace(/[\/\\]/g, "_").replace(
-            /\.\./g,
-            "_",
-          ).replace(/\0/g, ""),
-        );
-        if (!content) {
-          throw new Error("No existing state found - run create or get first");
-        }
-        const existing = JSON.parse(new TextDecoder().decode(content));
-        params["healthSource"] = existing["name"]?.toString() ??
-          g["name"]?.toString() ?? "";
-        const result = await createResource(
-          BASE_URL,
-          {
-            "id": "compute.regionHealthSources.getHealth",
-            "path":
-              "projects/{project}/regions/{region}/healthSources/{healthSource}/getHealth",
-            "httpMethod": "GET",
-            "parameterOrder": ["project", "region", "healthSource"],
-            "parameters": {
-              "healthSource": { "location": "path", "required": true },
-              "project": { "location": "path", "required": true },
-              "region": { "location": "path", "required": true },
-            },
-          },
-          params,
-          {},
-        );
-        return { result };
       },
     },
   },

--- a/model/gcp/compute/extensions/models/regioninstancegroupmanagers.ts
+++ b/model/gcp/compute/extensions/models/regioninstancegroupmanagers.ts
@@ -150,43 +150,43 @@ const GlobalArgsSchema = z.object({
   ).optional(),
   currentActions: z.object({
     abandoning: z.number().int().describe(
-      "Output only. The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
+      "Output only. [Output Only] The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
     ).optional(),
     creating: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
     ).optional(),
     creatingWithoutRetries: z.number().int().describe(
-      "Output only. The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
+      "Output only. [Output Only] The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
     ).optional(),
     deleting: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
     ).optional(),
     none: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are running and have no scheduled actions.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are running and have no scheduled actions.",
     ).optional(),
     recreating: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
     ).optional(),
     refreshing: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
     ).optional(),
     restarting: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
     ).optional(),
     resuming: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
     ).optional(),
     starting: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
     ).optional(),
     stopping: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
     ).optional(),
     suspending: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
     ).optional(),
     verifying: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
     ).optional(),
   }).optional(),
   description: z.string().describe("An optional description of this resource.")
@@ -300,15 +300,15 @@ const GlobalArgsSchema = z.object({
   status: z.object({
     allInstancesConfig: z.object({
       currentRevision: z.string().describe(
-        "Output only. Current all-instances configuration revision. This value is in RFC3339 text format.",
+        "Output only. [Output Only] Current all-instances configuration revision. This value is in RFC3339 text format.",
       ).optional(),
       effective: z.boolean().describe(
-        "Output only. A bit indicating whether this configuration has been applied to all managed instances in the group.",
+        "Output only. [Output Only] A bit indicating whether this configuration has been applied to all managed instances in the group.",
       ).optional(),
     }).optional(),
     appliedAcceleratorTopologies: z.array(z.object({
       acceleratorTopology: z.string().describe(
-        'Output only. Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
+        'Output only. [Output Only] Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
       ).optional(),
       state: z.enum([
         "ACTIVATING",
@@ -317,27 +317,29 @@ const GlobalArgsSchema = z.object({
         "FAILED",
         "INCOMPLETE",
         "REACTIVATING",
-      ]).describe("Output only. The state of the accelerator topology.")
-        .optional(),
+      ]).describe(
+        "Output only. [Output Only] The state of the accelerator topology.",
+      ).optional(),
       stateDetails: z.object({
         error: z.object({
           errors: z.unknown().describe(
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
-        }).describe("Output only. Encountered errors.").optional(),
+        }).describe("Output only. [Output Only] Encountered errors.")
+          .optional(),
         timestamp: z.string().describe(
-          "Output only. Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
+          "Output only. [Output Only] Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
         ).optional(),
       }).optional(),
     })).describe(
-      "Output only. The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
+      "Output only. [Output Only] The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
     ).optional(),
     autoscaler: z.string().describe(
-      "Output only. The URL of theAutoscaler that targets this instance group manager.",
+      "Output only. [Output Only] The URL of theAutoscaler that targets this instance group manager.",
     ).optional(),
     bulkInstanceOperation: z.object({
       inProgress: z.boolean().describe(
-        "Output only. Informs whether bulk instance operation is in progress.",
+        "Output only. [Output Only] Informs whether bulk instance operation is in progress.",
       ).optional(),
       lastProgressCheck: z.object({
         error: z.object({
@@ -345,64 +347,21 @@ const GlobalArgsSchema = z.object({
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
         }).describe(
-          "Output only. Errors encountered during bulk instance operation.",
+          "Output only. [Output Only] Errors encountered during bulk instance operation.",
         ).optional(),
         timestamp: z.string().describe(
-          "Output only. Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
+          "Output only. [Output Only] Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
         ).optional(),
       }).optional(),
     }).describe(
       "Bulk instance operation is the creation of VMs in a MIG when the targetSizePolicy.mode is set to BULK.",
     ).optional(),
-    currentInstanceStatuses: z.object({
-      deprovisioning: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have DEPROVISIONING status.",
-      ).optional(),
-      nonExistent: z.number().int().describe(
-        "Output only. The number of instances that have not been created yet or have been deleted. Includes only instances that would be shown in the listManagedInstances method and not all instances that have been deleted in the lifetime of the MIG. Does not include FlexStart instances that are waiting for the resources availability, they are considered as 'pending'.",
-      ).optional(),
-      pending: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have PENDING status, that is FlexStart instances that are waiting for resources. Instances that do not exist because of the other reasons are counted as 'non_existent'.",
-      ).optional(),
-      pendingStop: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have PENDING_STOP status.",
-      ).optional(),
-      provisioning: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have PROVISIONING status.",
-      ).optional(),
-      repairing: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have REPAIRING status.",
-      ).optional(),
-      running: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have RUNNING status.",
-      ).optional(),
-      staging: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have STAGING status.",
-      ).optional(),
-      stopped: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have STOPPED status.",
-      ).optional(),
-      stopping: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have STOPPING status.",
-      ).optional(),
-      suspended: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have SUSPENDED status.",
-      ).optional(),
-      suspending: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have SUSPENDING status.",
-      ).optional(),
-      terminated: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have TERMINATED status.",
-      ).optional(),
-    }).describe(
-      "The list of instance statuses and the number of instances in this managed instance group that have the status. For more information about how to interpret each status check the instance lifecycle documentation. Currently only shown for TPU MIGs.",
-    ).optional(),
     isStable: z.boolean().describe(
-      "Output only. A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
+      "Output only. [Output Only] A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
     ).optional(),
     stateful: z.object({
       hasStatefulConfig: z.boolean().describe(
-        "Output only. A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
+        "Output only. [Output Only] A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
       ).optional(),
       perInstanceConfigs: z.object({
         allEffective: z.boolean().describe(
@@ -412,7 +371,7 @@ const GlobalArgsSchema = z.object({
     }).optional(),
     versionTarget: z.object({
       isReached: z.boolean().describe(
-        "Output only. A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
+        "Output only. [Output Only] A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
       ).optional(),
     }).optional(),
   }).optional(),
@@ -606,21 +565,6 @@ const StateSchema = z.object({
         timestamp: z.string(),
       }),
     }),
-    currentInstanceStatuses: z.object({
-      deprovisioning: z.number(),
-      nonExistent: z.number(),
-      pending: z.number(),
-      pendingStop: z.number(),
-      provisioning: z.number(),
-      repairing: z.number(),
-      running: z.number(),
-      staging: z.number(),
-      stopped: z.number(),
-      stopping: z.number(),
-      suspended: z.number(),
-      suspending: z.number(),
-      terminated: z.number(),
-    }),
     isStable: z.boolean(),
     stateful: z.object({
       hasStatefulConfig: z.boolean(),
@@ -698,43 +642,43 @@ const InputsSchema = z.object({
   ).optional(),
   currentActions: z.object({
     abandoning: z.number().int().describe(
-      "Output only. The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
+      "Output only. [Output Only] The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
     ).optional(),
     creating: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
     ).optional(),
     creatingWithoutRetries: z.number().int().describe(
-      "Output only. The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
+      "Output only. [Output Only] The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
     ).optional(),
     deleting: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
     ).optional(),
     none: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are running and have no scheduled actions.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are running and have no scheduled actions.",
     ).optional(),
     recreating: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
     ).optional(),
     refreshing: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
     ).optional(),
     restarting: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
     ).optional(),
     resuming: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
     ).optional(),
     starting: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
     ).optional(),
     stopping: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
     ).optional(),
     suspending: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
     ).optional(),
     verifying: z.number().int().describe(
-      "Output only. The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
+      "Output only. [Output Only] The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
     ).optional(),
   }).optional(),
   description: z.string().describe("An optional description of this resource.")
@@ -848,15 +792,15 @@ const InputsSchema = z.object({
   status: z.object({
     allInstancesConfig: z.object({
       currentRevision: z.string().describe(
-        "Output only. Current all-instances configuration revision. This value is in RFC3339 text format.",
+        "Output only. [Output Only] Current all-instances configuration revision. This value is in RFC3339 text format.",
       ).optional(),
       effective: z.boolean().describe(
-        "Output only. A bit indicating whether this configuration has been applied to all managed instances in the group.",
+        "Output only. [Output Only] A bit indicating whether this configuration has been applied to all managed instances in the group.",
       ).optional(),
     }).optional(),
     appliedAcceleratorTopologies: z.array(z.object({
       acceleratorTopology: z.string().describe(
-        'Output only. Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
+        'Output only. [Output Only] Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
       ).optional(),
       state: z.enum([
         "ACTIVATING",
@@ -865,27 +809,29 @@ const InputsSchema = z.object({
         "FAILED",
         "INCOMPLETE",
         "REACTIVATING",
-      ]).describe("Output only. The state of the accelerator topology.")
-        .optional(),
+      ]).describe(
+        "Output only. [Output Only] The state of the accelerator topology.",
+      ).optional(),
       stateDetails: z.object({
         error: z.object({
           errors: z.unknown().describe(
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
-        }).describe("Output only. Encountered errors.").optional(),
+        }).describe("Output only. [Output Only] Encountered errors.")
+          .optional(),
         timestamp: z.string().describe(
-          "Output only. Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
+          "Output only. [Output Only] Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
         ).optional(),
       }).optional(),
     })).describe(
-      "Output only. The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
+      "Output only. [Output Only] The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
     ).optional(),
     autoscaler: z.string().describe(
-      "Output only. The URL of theAutoscaler that targets this instance group manager.",
+      "Output only. [Output Only] The URL of theAutoscaler that targets this instance group manager.",
     ).optional(),
     bulkInstanceOperation: z.object({
       inProgress: z.boolean().describe(
-        "Output only. Informs whether bulk instance operation is in progress.",
+        "Output only. [Output Only] Informs whether bulk instance operation is in progress.",
       ).optional(),
       lastProgressCheck: z.object({
         error: z.object({
@@ -893,64 +839,21 @@ const InputsSchema = z.object({
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
         }).describe(
-          "Output only. Errors encountered during bulk instance operation.",
+          "Output only. [Output Only] Errors encountered during bulk instance operation.",
         ).optional(),
         timestamp: z.string().describe(
-          "Output only. Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
+          "Output only. [Output Only] Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
         ).optional(),
       }).optional(),
     }).describe(
       "Bulk instance operation is the creation of VMs in a MIG when the targetSizePolicy.mode is set to BULK.",
     ).optional(),
-    currentInstanceStatuses: z.object({
-      deprovisioning: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have DEPROVISIONING status.",
-      ).optional(),
-      nonExistent: z.number().int().describe(
-        "Output only. The number of instances that have not been created yet or have been deleted. Includes only instances that would be shown in the listManagedInstances method and not all instances that have been deleted in the lifetime of the MIG. Does not include FlexStart instances that are waiting for the resources availability, they are considered as 'pending'.",
-      ).optional(),
-      pending: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have PENDING status, that is FlexStart instances that are waiting for resources. Instances that do not exist because of the other reasons are counted as 'non_existent'.",
-      ).optional(),
-      pendingStop: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have PENDING_STOP status.",
-      ).optional(),
-      provisioning: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have PROVISIONING status.",
-      ).optional(),
-      repairing: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have REPAIRING status.",
-      ).optional(),
-      running: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have RUNNING status.",
-      ).optional(),
-      staging: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have STAGING status.",
-      ).optional(),
-      stopped: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have STOPPED status.",
-      ).optional(),
-      stopping: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have STOPPING status.",
-      ).optional(),
-      suspended: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have SUSPENDED status.",
-      ).optional(),
-      suspending: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have SUSPENDING status.",
-      ).optional(),
-      terminated: z.number().int().describe(
-        "Output only. The number of instances in the managed instance group that have TERMINATED status.",
-      ).optional(),
-    }).describe(
-      "The list of instance statuses and the number of instances in this managed instance group that have the status. For more information about how to interpret each status check the instance lifecycle documentation. Currently only shown for TPU MIGs.",
-    ).optional(),
     isStable: z.boolean().describe(
-      "Output only. A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
+      "Output only. [Output Only] A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
     ).optional(),
     stateful: z.object({
       hasStatefulConfig: z.boolean().describe(
-        "Output only. A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
+        "Output only. [Output Only] A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
       ).optional(),
       perInstanceConfigs: z.object({
         allEffective: z.boolean().describe(
@@ -960,7 +863,7 @@ const InputsSchema = z.object({
     }).optional(),
     versionTarget: z.object({
       isReached: z.boolean().describe(
-        "Output only. A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
+        "Output only. [Output Only] A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
       ).optional(),
     }).optional(),
   }).optional(),
@@ -1059,7 +962,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regioninstancegroupmanagers",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1098,6 +1001,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/regioninstancetemplates.ts
+++ b/model/gcp/compute/extensions/models/regioninstancetemplates.ts
@@ -183,7 +183,7 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -497,9 +497,6 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
-      ).optional(),
-      serviceClassId: z.string().describe(
-        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
       ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
@@ -849,7 +846,6 @@ const StateSchema = z.object({
       nicType: z.string(),
       parentNicName: z.string(),
       queueCount: z.number(),
-      serviceClassId: z.string(),
       stackType: z.string(),
       subnetwork: z.string(),
       vlan: z.number(),
@@ -1018,7 +1014,7 @@ const InputsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -1333,9 +1329,6 @@ const InputsSchema = z.object({
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
       ).optional(),
-      serviceClassId: z.string().describe(
-        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
-      ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
       ).optional(),
@@ -1538,7 +1531,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regioninstancetemplates",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1577,6 +1570,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/regioninstantsnapshots.ts
+++ b/model/gcp/compute/extensions/models/regioninstantsnapshots.ts
@@ -150,8 +150,6 @@ const StateSchema = z.object({
   selfLinkWithId: z.string().optional(),
   sourceDisk: z.string().optional(),
   sourceDiskId: z.string().optional(),
-  sourceInstantSnapshotGroup: z.string().optional(),
-  sourceInstantSnapshotGroupId: z.string().optional(),
   status: z.string().optional(),
   zone: z.string().optional(),
 }).passthrough();
@@ -195,7 +193,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regioninstantsnapshots",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -224,6 +222,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/reservations.ts
+++ b/model/gcp/compute/extensions/models/reservations.ts
@@ -179,10 +179,6 @@ const GlobalArgsSchema = z.object({
   }).describe(
     "This reservation type is specified by total resource amounts (e.g. total count of CPUs) and can account for multiple instance SKUs. In other words, one can create instances of varying shapes against this reservation.",
   ).optional(),
-  confidentialComputeType: z.enum([
-    "CONFIDENTIAL_COMPUTE_TYPE_TDX",
-    "CONFIDENTIAL_COMPUTE_TYPE_UNSPECIFIED",
-  ]).optional(),
   deleteAfterDuration: z.object({
     nanos: z.number().int().describe(
       "Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented with a 0 `seconds` field and a positive `nanos` field. Must be from 0 to 999,999,999 inclusive.",
@@ -338,7 +334,6 @@ const StateSchema = z.object({
     workloadType: z.string(),
   }).optional(),
   commitment: z.string().optional(),
-  confidentialComputeType: z.string().optional(),
   creationTimestamp: z.string().optional(),
   deleteAfterDuration: z.object({
     nanos: z.number(),
@@ -479,10 +474,6 @@ const InputsSchema = z.object({
   }).describe(
     "This reservation type is specified by total resource amounts (e.g. total count of CPUs) and can account for multiple instance SKUs. In other words, one can create instances of varying shapes against this reservation.",
   ).optional(),
-  confidentialComputeType: z.enum([
-    "CONFIDENTIAL_COMPUTE_TYPE_TDX",
-    "CONFIDENTIAL_COMPUTE_TYPE_UNSPECIFIED",
-  ]).optional(),
   deleteAfterDuration: z.object({
     nanos: z.number().int().describe(
       "Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented with a 0 `seconds` field and a positive `nanos` field. Must be from 0 to 999,999,999 inclusive.",
@@ -619,7 +610,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/reservations",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -665,6 +656,15 @@ export const model = {
       description: "Added: confidentialComputeType",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
+    {
+      toVersion: "2026.04.04.2",
+      description: "Removed: confidentialComputeType",
+      upgradeAttributes: (old: Record<string, unknown>) => {
+        const { confidentialComputeType: _confidentialComputeType, ...rest } =
+          old;
+        return rest;
+      },
+    },
   ],
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
@@ -696,9 +696,6 @@ export const model = {
         }
         if (g["aggregateReservation"] !== undefined) {
           body["aggregateReservation"] = g["aggregateReservation"];
-        }
-        if (g["confidentialComputeType"] !== undefined) {
-          body["confidentialComputeType"] = g["confidentialComputeType"];
         }
         if (g["deleteAfterDuration"] !== undefined) {
           body["deleteAfterDuration"] = g["deleteAfterDuration"];
@@ -830,9 +827,6 @@ export const model = {
         }
         if (g["aggregateReservation"] !== undefined) {
           body["aggregateReservation"] = g["aggregateReservation"];
-        }
-        if (g["confidentialComputeType"] !== undefined) {
-          body["confidentialComputeType"] = g["confidentialComputeType"];
         }
         if (g["deleteAfterDuration"] !== undefined) {
           body["deleteAfterDuration"] = g["deleteAfterDuration"];

--- a/model/gcp/compute/extensions/models/snapshots.ts
+++ b/model/gcp/compute/extensions/models/snapshots.ts
@@ -199,7 +199,6 @@ const StateSchema = z.object({
   params: z.object({
     resourceManagerTags: z.record(z.string(), z.unknown()),
   }).optional(),
-  region: z.string().optional(),
   satisfiesPzi: z.boolean().optional(),
   satisfiesPzs: z.boolean().optional(),
   selfLink: z.string().optional(),
@@ -210,8 +209,6 @@ const StateSchema = z.object({
     rsaEncryptedKey: z.string(),
     sha256: z.string(),
   }).optional(),
-  snapshotGroupId: z.string().optional(),
-  snapshotGroupName: z.string().optional(),
   snapshotType: z.string().optional(),
   sourceDisk: z.string().optional(),
   sourceDiskEncryptionKey: z.object({
@@ -343,7 +340,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/snapshots",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -382,6 +379,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -620,53 +622,6 @@ export const model = {
             "parameters": {
               "project": { "location": "path", "required": true },
               "resource": { "location": "path", "required": true },
-            },
-          },
-          params,
-          body,
-        );
-        return { result };
-      },
-    },
-    update_kms_key: {
-      description: "update kms key",
-      arguments: z.object({
-        kmsKeyName: z.any().optional(),
-      }),
-      execute: async (args: Record<string, unknown>, context: any) => {
-        const g = context.globalArgs;
-        const projectId = await getProjectId();
-        const params: Record<string, string> = { project: projectId };
-        const content = await context.dataRepository.getContent(
-          context.modelType,
-          context.modelId,
-          (g.name?.toString() ?? "current").replace(/[\/\\]/g, "_").replace(
-            /\.\./g,
-            "_",
-          ).replace(/\0/g, ""),
-        );
-        if (!content) {
-          throw new Error("No existing state found - run create or get first");
-        }
-        const existing = JSON.parse(new TextDecoder().decode(content));
-        params["snapshot"] = existing["name"]?.toString() ??
-          g["name"]?.toString() ?? "";
-        const body: Record<string, unknown> = {};
-        if (args["kmsKeyName"] !== undefined) {
-          body["kmsKeyName"] = args["kmsKeyName"];
-        }
-        const result = await createResource(
-          BASE_URL,
-          {
-            "id": "compute.snapshots.updateKmsKey",
-            "path":
-              "projects/{project}/global/snapshots/{snapshot}/updateKmsKey",
-            "httpMethod": "POST",
-            "parameterOrder": ["project", "snapshot"],
-            "parameters": {
-              "project": { "location": "path", "required": true },
-              "requestId": { "location": "query" },
-              "snapshot": { "location": "path", "required": true },
             },
           },
           params,

--- a/model/gcp/compute/extensions/models/snapshotsettings.ts
+++ b/model/gcp/compute/extensions/models/snapshotsettings.ts
@@ -53,19 +53,6 @@ const GlobalArgsSchema = z.object({
   name: z.string().describe(
     "Instance name for this resource (used as the unique identifier in the factory pattern)",
   ),
-  accessLocation: z.object({
-    locations: z.record(
-      z.string(),
-      z.object({
-        region: z.string().describe("Accessible region name").optional(),
-      }),
-    ).describe(
-      "List of regions that can restore a regional snapshot from the current region",
-    ).optional(),
-    policy: z.enum(["ALL_REGIONS", "POLICY_UNSPECIFIED", "SPECIFIC_REGIONS"])
-      .describe("Policy of which location is allowed to access snapshot.")
-      .optional(),
-  }).optional(),
   storageLocation: z.object({
     locations: z.record(
       z.string(),
@@ -87,10 +74,6 @@ const GlobalArgsSchema = z.object({
 });
 
 const StateSchema = z.object({
-  accessLocation: z.object({
-    locations: z.record(z.string(), z.unknown()),
-    policy: z.string(),
-  }).optional(),
   storageLocation: z.object({
     locations: z.record(z.string(), z.unknown()),
     policy: z.string(),
@@ -101,19 +84,6 @@ type StateData = z.infer<typeof StateSchema>;
 
 const InputsSchema = z.object({
   name: z.string().optional(),
-  accessLocation: z.object({
-    locations: z.record(
-      z.string(),
-      z.object({
-        region: z.string().describe("Accessible region name").optional(),
-      }),
-    ).describe(
-      "List of regions that can restore a regional snapshot from the current region",
-    ).optional(),
-    policy: z.enum(["ALL_REGIONS", "POLICY_UNSPECIFIED", "SPECIFIC_REGIONS"])
-      .describe("Policy of which location is allowed to access snapshot.")
-      .optional(),
-  }).optional(),
   storageLocation: z.object({
     locations: z.record(
       z.string(),
@@ -136,7 +106,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/snapshotsettings",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -167,6 +137,14 @@ export const model = {
       toVersion: "2026.04.04.1",
       description: "Added: accessLocation",
       upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
+      description: "Removed: accessLocation",
+      upgradeAttributes: (old: Record<string, unknown>) => {
+        const { accessLocation: _accessLocation, ...rest } = old;
+        return rest;
+      },
     },
   ],
   globalArguments: GlobalArgsSchema,
@@ -218,9 +196,6 @@ export const model = {
         ).replace(/\.\./g, "_").replace(/\0/g, "");
         const params: Record<string, string> = { project: projectId };
         const body: Record<string, unknown> = {};
-        if (g["accessLocation"] !== undefined) {
-          body["accessLocation"] = g["accessLocation"];
-        }
         if (g["storageLocation"] !== undefined) {
           body["storageLocation"] = g["storageLocation"];
         }

--- a/model/gcp/compute/manifest.yaml
+++ b/model/gcp/compute/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/gcp/compute"
-version: "2026.04.04.1"
+version: "2026.04.04.2"
 description: "Google Cloud compute infrastructure models"
 labels:
   - gcp
@@ -10,8 +10,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Added: instantsnapshotgroups, regioninstantsnapshotgroups, regionsnapshotsettings, regionsnapshots
-  - Updated: backendbuckets, backendservices, disks, firewallpolicies, futurereservations, images, instancegroupmanagerresizerequests, instancegroupmanagers, instancetemplates, instances, instantsnapshots, interconnectattachmentgroups, interconnectattachments, interconnectgroups, machineimages, networkattachments, networkfirewallpolicies, organizationsecuritypolicies, regionbackendbuckets, regionbackendservices, regioncommitments, regioncompositehealthchecks, regiondisks, regionhealthsources, regioninstancegroupmanagerresizerequests, regioninstancegroupmanagers, regioninstancetemplates, regioninstantsnapshots, regionnetworkfirewallpolicies, regionsecuritypolicies, regionurlmaps, reservationblocks, reservationsubblocks, reservations, resourcepolicies, routers, securitypolicies, snapshotsettings, snapshots, urlmaps, wiregroups, zonevmextensionpolicies
+  - Updated: backendbuckets, backendservices, disks, futurereservations, images, instancegroupmanagerresizerequests, instancegroupmanagers, instancetemplates, instances, instantsnapshots, machineimages, networkattachments, regionbackendservices, regioncommitments, regioncompositehealthchecks, regiondisks, regionhealthsources, regioninstancegroupmanagers, regioninstancetemplates, regioninstantsnapshots, reservations, snapshotsettings, snapshots
 models:
   - acceleratortypes.ts
   - addresses.ts
@@ -41,7 +40,6 @@ models:
   - instances.ts
   - instancesettings.ts
   - instancetemplates.ts
-  - instantsnapshotgroups.ts
   - instantsnapshots.ts
   - interconnectattachmentgroups.ts
   - interconnectattachments.ts
@@ -69,7 +67,6 @@ models:
   - publicadvertisedprefixes.ts
   - publicdelegatedprefixes.ts
   - regionautoscalers.ts
-  - regionbackendbuckets.ts
   - regionbackendservices.ts
   - regioncommitments.ts
   - regioncompositehealthchecks.ts
@@ -79,19 +76,15 @@ models:
   - regionhealthchecks.ts
   - regionhealthcheckservices.ts
   - regionhealthsources.ts
-  - regioninstancegroupmanagerresizerequests.ts
   - regioninstancegroupmanagers.ts
   - regioninstancegroups.ts
   - regioninstancetemplates.ts
-  - regioninstantsnapshotgroups.ts
   - regioninstantsnapshots.ts
   - regionnetworkendpointgroups.ts
   - regionnetworkfirewallpolicies.ts
   - regionnotificationendpoints.ts
   - regions.ts
   - regionsecuritypolicies.ts
-  - regionsnapshots.ts
-  - regionsnapshotsettings.ts
   - regionsslcertificates.ts
   - regionsslpolicies.ts
   - regiontargethttpproxies.ts
@@ -128,7 +121,6 @@ models:
   - vpntunnels.ts
   - wiregroups.ts
   - zones.ts
-  - zonevmextensionpolicies.ts
 additionalFiles:
   - LICENSE.txt
   - README.md

--- a/model/gcp/dataplex/extensions/models/datascans.ts
+++ b/model/gcp/dataplex/extensions/models/datascans.ts
@@ -194,6 +194,15 @@ const GlobalArgsSchema = z.object({
           "Optional. Whether to disable the inference of data types for JSON data. If true, all columns are registered as their primitive types (strings, number, or boolean).",
         ).optional(),
       }).describe("Describes JSON data format.").optional(),
+      unstructuredDataOptions: z.object({
+        entityInferenceEnabled: z.boolean().describe(
+          "Optional. Deprecated: Use semantic_inference_enabled instead. Specifies whether deeper entity inference over the objects' contents using GenAI is enabled.",
+        ).optional(),
+        semanticInferenceEnabled: z.boolean().describe(
+          "Optional. Specifies whether deeper semantic inference over the objects' contents using GenAI is enabled.",
+        ).optional(),
+      }).describe("Describes options for unstructured data discovery.")
+        .optional(),
     }).describe("Configurations related to Cloud Storage as the data source.")
       .optional(),
   }).describe("Spec for a data discovery scan.").optional(),
@@ -240,24 +249,6 @@ const GlobalArgsSchema = z.object({
         ).optional(),
       })).describe(
         "Output only. Relationships suggesting how tables in the dataset are related to each other, based on their schema.",
-      ).optional(),
-      tableResults: z.array(z.object({
-        name: z.string().describe(
-          "Output only. The service-qualified full resource name of the cloud resource. Ex: //bigquery.googleapis.com/projects/PROJECT_ID/datasets/DATASET_ID/tables/TABLE_ID",
-        ).optional(),
-        overview: z.string().describe(
-          "Output only. Generated description of the table.",
-        ).optional(),
-        queries: z.array(z.unknown()).describe(
-          "Output only. Sample SQL queries for the table.",
-        ).optional(),
-        schema: z.object({
-          fields: z.unknown().describe("Output only. The list of columns.")
-            .optional(),
-        }).describe("Schema of the table with generated metadata of columns.")
-          .optional(),
-      })).describe(
-        "Output only. Generated table and column descriptions for each table in the dataset.",
       ).optional(),
     }).describe("Insights for a dataset resource.").optional(),
     tableResult: z.object({
@@ -397,6 +388,9 @@ const GlobalArgsSchema = z.object({
       ).optional(),
     }).describe(
       "The specification for fields to include or exclude in data profile scan.",
+    ).optional(),
+    mode: z.enum(["MODE_UNSPECIFIED", "STANDARD", "LIGHTWEIGHT"]).describe(
+      "Optional. The execution mode for the profile scan.",
     ).optional(),
     postScanActions: z.object({
       bigqueryExport: z.object({
@@ -804,6 +798,18 @@ const GlobalArgsSchema = z.object({
   displayName: z.string().describe(
     "Optional. User friendly display name. Must be between 1-256 characters.",
   ).optional(),
+  executionIdentity: z.object({
+    dataplexServiceAgent: z.object({}).describe(
+      "The Dataplex service agent associated with the user's project.",
+    ).optional(),
+    serviceAccount: z.object({
+      email: z.string().describe(
+        "Required. Service account email. The datascan will execute with this service account's credentials. The user calling this API must have permissions to act as this service account. Dataplex service agent must be granted iam.serviceAccounts.getAccessToken permission on this service account, for example, through the iam.serviceAccountTokenCreator role.",
+      ).optional(),
+    }).describe("The service account").optional(),
+    userCredential: z.object({}).describe("The credential of the calling user.")
+      .optional(),
+  }).describe("The identity to run the datascan.").optional(),
   executionSpec: z.object({
     field: z.string().describe(
       "Immutable. The unnested field (of type Date or Timestamp) that contains values which monotonically increase over time.If not specified, a data scan will run for all data in the table.",
@@ -889,6 +895,10 @@ const StateSchema = z.object({
         encoding: z.string(),
         typeInferenceDisabled: z.boolean(),
       }),
+      unstructuredDataOptions: z.object({
+        entityInferenceEnabled: z.boolean(),
+        semanticInferenceEnabled: z.boolean(),
+      }),
     }),
   }).optional(),
   dataDocumentationResult: z.object({
@@ -909,14 +919,6 @@ const StateSchema = z.object({
         }),
         sources: z.array(z.unknown()),
         type: z.string(),
-      })),
-      tableResults: z.array(z.object({
-        name: z.string(),
-        overview: z.string(),
-        queries: z.array(z.unknown()),
-        schema: z.object({
-          fields: z.unknown(),
-        }),
       })),
     }),
     tableResult: z.object({
@@ -981,6 +983,7 @@ const StateSchema = z.object({
     includeFields: z.object({
       fieldNames: z.array(z.string()),
     }),
+    mode: z.string(),
     postScanActions: z.object({
       bigqueryExport: z.object({
         resultsTable: z.string(),
@@ -1150,6 +1153,13 @@ const StateSchema = z.object({
   }).optional(),
   description: z.string().optional(),
   displayName: z.string().optional(),
+  executionIdentity: z.object({
+    dataplexServiceAgent: z.object({}),
+    serviceAccount: z.object({
+      email: z.string(),
+    }),
+    userCredential: z.object({}),
+  }).optional(),
   executionSpec: z.object({
     field: z.string(),
     trigger: z.object({
@@ -1271,6 +1281,15 @@ const InputsSchema = z.object({
           "Optional. Whether to disable the inference of data types for JSON data. If true, all columns are registered as their primitive types (strings, number, or boolean).",
         ).optional(),
       }).describe("Describes JSON data format.").optional(),
+      unstructuredDataOptions: z.object({
+        entityInferenceEnabled: z.boolean().describe(
+          "Optional. Deprecated: Use semantic_inference_enabled instead. Specifies whether deeper entity inference over the objects' contents using GenAI is enabled.",
+        ).optional(),
+        semanticInferenceEnabled: z.boolean().describe(
+          "Optional. Specifies whether deeper semantic inference over the objects' contents using GenAI is enabled.",
+        ).optional(),
+      }).describe("Describes options for unstructured data discovery.")
+        .optional(),
     }).describe("Configurations related to Cloud Storage as the data source.")
       .optional(),
   }).describe("Spec for a data discovery scan.").optional(),
@@ -1317,24 +1336,6 @@ const InputsSchema = z.object({
         ).optional(),
       })).describe(
         "Output only. Relationships suggesting how tables in the dataset are related to each other, based on their schema.",
-      ).optional(),
-      tableResults: z.array(z.object({
-        name: z.string().describe(
-          "Output only. The service-qualified full resource name of the cloud resource. Ex: //bigquery.googleapis.com/projects/PROJECT_ID/datasets/DATASET_ID/tables/TABLE_ID",
-        ).optional(),
-        overview: z.string().describe(
-          "Output only. Generated description of the table.",
-        ).optional(),
-        queries: z.array(z.unknown()).describe(
-          "Output only. Sample SQL queries for the table.",
-        ).optional(),
-        schema: z.object({
-          fields: z.unknown().describe("Output only. The list of columns.")
-            .optional(),
-        }).describe("Schema of the table with generated metadata of columns.")
-          .optional(),
-      })).describe(
-        "Output only. Generated table and column descriptions for each table in the dataset.",
       ).optional(),
     }).describe("Insights for a dataset resource.").optional(),
     tableResult: z.object({
@@ -1474,6 +1475,9 @@ const InputsSchema = z.object({
       ).optional(),
     }).describe(
       "The specification for fields to include or exclude in data profile scan.",
+    ).optional(),
+    mode: z.enum(["MODE_UNSPECIFIED", "STANDARD", "LIGHTWEIGHT"]).describe(
+      "Optional. The execution mode for the profile scan.",
     ).optional(),
     postScanActions: z.object({
       bigqueryExport: z.object({
@@ -1881,6 +1885,18 @@ const InputsSchema = z.object({
   displayName: z.string().describe(
     "Optional. User friendly display name. Must be between 1-256 characters.",
   ).optional(),
+  executionIdentity: z.object({
+    dataplexServiceAgent: z.object({}).describe(
+      "The Dataplex service agent associated with the user's project.",
+    ).optional(),
+    serviceAccount: z.object({
+      email: z.string().describe(
+        "Required. Service account email. The datascan will execute with this service account's credentials. The user calling this API must have permissions to act as this service account. Dataplex service agent must be granted iam.serviceAccounts.getAccessToken permission on this service account, for example, through the iam.serviceAccountTokenCreator role.",
+      ).optional(),
+    }).describe("The service account").optional(),
+    userCredential: z.object({}).describe("The credential of the calling user.")
+      .optional(),
+  }).describe("The identity to run the datascan.").optional(),
   executionSpec: z.object({
     field: z.string().describe(
       "Immutable. The unnested field (of type Date or Timestamp) that contains values which monotonically increase over time.If not specified, a data scan will run for all data in the table.",
@@ -1924,7 +1940,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/dataplex/datascans",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -1964,6 +1980,11 @@ export const model = {
     {
       toVersion: "2026.04.04.1",
       description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
+      description: "Added: executionIdentity",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
   ],
@@ -2022,6 +2043,9 @@ export const model = {
         }
         if (g["displayName"] !== undefined) {
           body["displayName"] = g["displayName"];
+        }
+        if (g["executionIdentity"] !== undefined) {
+          body["executionIdentity"] = g["executionIdentity"];
         }
         if (g["executionSpec"] !== undefined) {
           body["executionSpec"] = g["executionSpec"];
@@ -2152,6 +2176,9 @@ export const model = {
         }
         if (g["displayName"] !== undefined) {
           body["displayName"] = g["displayName"];
+        }
+        if (g["executionIdentity"] !== undefined) {
+          body["executionIdentity"] = g["executionIdentity"];
         }
         if (g["executionSpec"] !== undefined) {
           body["executionSpec"] = g["executionSpec"];

--- a/model/gcp/dataplex/extensions/models/datascans_jobs.ts
+++ b/model/gcp/dataplex/extensions/models/datascans_jobs.ts
@@ -85,6 +85,10 @@ const StateSchema = z.object({
         encoding: z.string(),
         typeInferenceDisabled: z.boolean(),
       }),
+      unstructuredDataOptions: z.object({
+        entityInferenceEnabled: z.boolean(),
+        semanticInferenceEnabled: z.boolean(),
+      }),
     }),
   }).optional(),
   dataDocumentationResult: z.object({
@@ -105,14 +109,6 @@ const StateSchema = z.object({
         }),
         sources: z.array(z.unknown()),
         type: z.string(),
-      })),
-      tableResults: z.array(z.object({
-        name: z.string(),
-        overview: z.string(),
-        queries: z.array(z.unknown()),
-        schema: z.object({
-          fields: z.unknown(),
-        }),
       })),
     }),
     tableResult: z.object({
@@ -177,6 +173,7 @@ const StateSchema = z.object({
     includeFields: z.object({
       fieldNames: z.array(z.string()),
     }),
+    mode: z.string(),
     postScanActions: z.object({
       bigqueryExport: z.object({
         resultsTable: z.string(),
@@ -347,6 +344,7 @@ const StateSchema = z.object({
   endTime: z.string().optional(),
   message: z.string().optional(),
   name: z.string(),
+  partialFailureMessage: z.string().optional(),
   startTime: z.string().optional(),
   state: z.string().optional(),
   type: z.string().optional(),
@@ -364,7 +362,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/dataplex/datascans-jobs",
-  version: "2026.04.04.1",
+  version: "2026.04.04.2",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -403,6 +401,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.2",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/dataplex/extensions/models/locations.ts
+++ b/model/gcp/dataplex/extensions/models/locations.ts
@@ -50,7 +50,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/dataplex/locations",
-  version: "2026.04.03.3",
+  version: "2026.04.04.1",
   upgrades: [
     {
       toVersion: "2026.04.01.2",
@@ -74,6 +74,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.03.3",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -253,6 +258,45 @@ export const model = {
           },
           params,
           {},
+        );
+        return { result };
+      },
+    },
+    modify_entry: {
+      description: "modify entry",
+      arguments: z.object({
+        aspectKeys: z.any().optional(),
+        deleteMissingAspects: z.any().optional(),
+        entry: z.any().optional(),
+        updateMask: z.any().optional(),
+      }),
+      execute: async (args: Record<string, unknown>, context: any) => {
+        const g = context.globalArgs;
+        const projectId = await getProjectId();
+        const params: Record<string, string> = { project: projectId };
+        if (g["name"] !== undefined) params["name"] = String(g["name"]);
+        const body: Record<string, unknown> = {};
+        if (args["aspectKeys"] !== undefined) {
+          body["aspectKeys"] = args["aspectKeys"];
+        }
+        if (args["deleteMissingAspects"] !== undefined) {
+          body["deleteMissingAspects"] = args["deleteMissingAspects"];
+        }
+        if (args["entry"] !== undefined) body["entry"] = args["entry"];
+        if (args["updateMask"] !== undefined) {
+          body["updateMask"] = args["updateMask"];
+        }
+        const result = await createResource(
+          BASE_URL,
+          {
+            "id": "dataplex.projects.locations.modifyEntry",
+            "path": "v1/{+name}:modifyEntry",
+            "httpMethod": "POST",
+            "parameterOrder": ["name"],
+            "parameters": { "name": { "location": "path", "required": true } },
+          },
+          params,
+          body,
         );
         return { result };
       },

--- a/model/gcp/dataplex/manifest.yaml
+++ b/model/gcp/dataplex/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/gcp/dataplex"
-version: "2026.04.04.1"
+version: "2026.04.04.2"
 description: "Google Cloud dataplex infrastructure models"
 labels:
   - gcp
@@ -10,7 +10,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: datascans, datascans_jobs
+  - Updated: locations, datascans, datascans_jobs
 models:
   - aspecttypes.ts
   - dataattributebindings.ts

--- a/model/gcp/logging/extensions/models/entries.ts
+++ b/model/gcp/logging/extensions/models/entries.ts
@@ -113,6 +113,7 @@ const StateSchema = z.object({
     last: z.boolean(),
     producer: z.string(),
   }).optional(),
+  otel: z.record(z.string(), z.unknown()).optional(),
   protoPayload: z.record(z.string(), z.unknown()).optional(),
   receiveTimestamp: z.string().optional(),
   resource: z.object({
@@ -145,7 +146,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/logging/entries",
-  version: "2026.04.03.3",
+  version: "2026.04.04.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -169,6 +170,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.03.3",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.04.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/logging/manifest.yaml
+++ b/model/gcp/logging/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/gcp/logging"
-version: "2026.04.04.1"
+version: "2026.04.04.2"
 description: "Google Cloud logging infrastructure models"
 labels:
   - gcp
@@ -10,7 +10,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: recentqueries, savedqueries
+  - Updated: entries
 models:
   - buckets.ts
   - buckets_links.ts


### PR DESCRIPTION
## Summary

Automated regeneration of extension models from upstream provider schemas.

### Changes

- **aws**: 2 files changed
- **gcp**: 32 files changed


### Schema Sources

- **AWS**: CloudFormation Resource Schema
- **GCP**: Google Discovery Documents
- **Hetzner**: Hetzner Cloud OpenAPI spec
- **DigitalOcean**: DigitalOcean OpenAPI spec

### Review Notes

- Files under `model/` are auto-generated — review the `manifest.yaml` diffs for version changes
- CalVer versioning with content-based change detection ensures versions only bump when content changes
- Publishing happens automatically when this PR is merged (via the publish workflow)

