### PR TITLE
chore: regenerate models from upstream schemas

### DIFF
--- a/model/gcp/aiplatform/extensions/models/reasoningengines_memories.ts
+++ b/model/gcp/aiplatform/extensions/models/reasoningengines_memories.ts
@@ -98,7 +98,7 @@ const GlobalArgsSchema = z.object({
     "Optional. Timestamp of when this resource is considered expired. This is *always* provided on output when `expiration` is set on input, regardless of whether `expire_time` or `ttl` was provided.",
   ).optional(),
   fact: z.string().describe(
-    "Required. Semantic knowledge extracted from the source content.",
+    "Optional. Semantic knowledge extracted from the source content.",
   ).optional(),
   metadata: z.record(
     z.string(),
@@ -186,7 +186,7 @@ const InputsSchema = z.object({
     "Optional. Timestamp of when this resource is considered expired. This is *always* provided on output when `expiration` is set on input, regardless of whether `expire_time` or `ttl` was provided.",
   ).optional(),
   fact: z.string().describe(
-    "Required. Semantic knowledge extracted from the source content.",
+    "Optional. Semantic knowledge extracted from the source content.",
   ).optional(),
   metadata: z.record(
     z.string(),
@@ -241,7 +241,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/aiplatform/reasoningengines-memories",
-  version: "2026.04.03.3",
+  version: "2026.04.05.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -265,6 +265,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.03.3",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.05.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/aiplatform/manifest.yaml
+++ b/model/gcp/aiplatform/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/gcp/aiplatform"
-version: "2026.04.04.1"
+version: "2026.04.05.1"
 description: "Google Cloud aiplatform infrastructure models"
 labels:
   - gcp
@@ -10,7 +10,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: batchpredictionjobs, cachedcontents, customjobs, deploymentresourcepools, endpoints, evaluationitems, evaluationruns, hyperparametertuningjobs, indexendpoints, modeldeploymentmonitoringjobs, models, models_evaluations, nasjobs, persistentresources, pipelinejobs, ragcorpora_ragfiles, reasoningengines, reasoningengines_sessions_events, schedules, studies, trainingpipelines, tuningjobs, publishers_models
+  - Updated: reasoningengines_memories
 models:
   - batchpredictionjobs.ts
   - cachedcontents.ts


### PR DESCRIPTION
## Summary

Automated regeneration of extension models from upstream provider schemas.

### Changes

- **gcp**: 2 files changed


### Schema Sources

- **AWS**: CloudFormation Resource Schema
- **GCP**: Google Discovery Documents
- **Hetzner**: Hetzner Cloud OpenAPI spec
- **DigitalOcean**: DigitalOcean OpenAPI spec

### Review Notes

- Files under `model/` are auto-generated — review the `manifest.yaml` diffs for version changes
- CalVer versioning with content-based change detection ensures versions only bump when content changes
- Publishing happens automatically when this PR is merged (via the publish workflow)

