### PR TITLE
chore: regenerate models from upstream schemas

### DIFF
--- a/model/aws/s3express/extensions/models/directory_bucket.ts
+++ b/model/aws/s3express/extensions/models/directory_bucket.ts
@@ -13,10 +13,10 @@ import {
 } from "./_lib/aws.ts";
 
 export const ServerSideEncryptionByDefaultSchema = z.object({
-  SSEAlgorithm: z.enum(["aws:kms", "AES256"]),
   KMSMasterKeyID: z.string().describe(
     "AWS Key Management Service (KMS) customer managed key ID to use for the default encryption. This parameter is allowed only if SSEAlgorithm is set to aws:kms. You can specify this parameter with the key ID or the Amazon Resource Name (ARN) of the KMS key",
   ).optional(),
+  SSEAlgorithm: z.enum(["aws:kms", "AES256"]),
 });
 
 export const ServerSideEncryptionRuleSchema = z.object({
@@ -35,25 +35,36 @@ export const AbortIncompleteMultipartUploadSchema = z.object({
 });
 
 export const RuleSchema = z.object({
-  Status: z.enum(["Enabled", "Disabled"]),
-  ExpirationInDays: z.number().int().optional(),
-  ObjectSizeGreaterThan: z.string().max(20).regex(new RegExp("[0-9]+"))
-    .optional(),
-  Id: z.string().max(255).optional(),
-  Prefix: z.string().optional(),
   AbortIncompleteMultipartUpload: AbortIncompleteMultipartUploadSchema.describe(
     "Specifies the days since the initiation of an incomplete multipart upload that Amazon S3 will wait before permanently removing all parts of the upload.",
   ).optional(),
+  ExpirationInDays: z.number().int().optional(),
+  Id: z.string().max(255).optional(),
+  Prefix: z.string().optional(),
+  Status: z.enum(["Enabled", "Disabled"]),
+  ObjectSizeGreaterThan: z.string().max(20).regex(new RegExp("[0-9]+"))
+    .optional(),
   ObjectSizeLessThan: z.string().max(20).regex(new RegExp("[0-9]+")).optional(),
 });
 
 export const TagSchema = z.object({
-  Value: z.string().min(0).max(256).regex(
-    new RegExp("^([\\p{L}\\p{Z}\\p{N}_.:=+\\/\\-@%]*)$", "u"),
-  ),
   Key: z.string().min(1).max(128).regex(
     new RegExp("^(?!aws:.*)([\\p{L}\\p{Z}\\p{N}_.:=+\\/\\-@%]*)$", "u"),
   ),
+  Value: z.string().min(0).max(256).regex(
+    new RegExp("^([\\p{L}\\p{Z}\\p{N}_.:=+\\/\\-@%]*)$", "u"),
+  ),
+});
+
+export const MetricsConfigurationSchema = z.object({
+  Id: z.string().describe("The ID used to identify the metrics configuration.")
+    .optional(),
+  Prefix: z.string().describe(
+    "The prefix used when evaluating a metrics filter.",
+  ).optional(),
+  AccessPointArn: z.string().describe(
+    "The access point ARN used when evaluating a metrics filter.",
+  ).optional(),
 });
 
 const GlobalArgsSchema = z.object({
@@ -62,16 +73,19 @@ const GlobalArgsSchema = z.object({
   ).describe(
     "Specifies a name for the bucket. The bucket name must contain only lowercase letters, numbers, and hyphens (-). A directory bucket name must be unique in the chosen Availability Zone or Local Zone. The bucket name must also follow the format 'bucket_base_name--zone_id--x-s3'. The zone_id can be the ID of an Availability Zone or a Local Zone. If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the bucket name.",
   ).optional(),
+  LocationName: z.string().describe(
+    "Specifies the Zone ID of the Availability Zone or Local Zone where the directory bucket will be created. An example Availability Zone ID value is 'use1-az5'.",
+  ),
+  DataRedundancy: z.enum(["SingleAvailabilityZone", "SingleLocalZone"])
+    .describe(
+      "Specifies the number of Availability Zone or Local Zone that's used for redundancy for the bucket.",
+    ),
   BucketEncryption: z.object({
     ServerSideEncryptionConfiguration: z.array(ServerSideEncryptionRuleSchema)
       .describe("Specifies the default server-side-encryption configuration."),
   }).describe(
     "Specifies default encryption for a bucket using server-side encryption with Amazon S3 managed keys (SSE-S3) or AWS KMS keys (SSE-KMS).",
   ).optional(),
-  DataRedundancy: z.enum(["SingleAvailabilityZone", "SingleLocalZone"])
-    .describe(
-      "Specifies the number of Availability Zone or Local Zone that's used for redundancy for the bucket.",
-    ),
   LifecycleConfiguration: z.object({
     Rules: z.array(RuleSchema).describe(
       "A lifecycle rule for individual objects in an Amazon S3 Express bucket.",
@@ -80,24 +94,25 @@ const GlobalArgsSchema = z.object({
     "Lifecycle rules that define how Amazon S3 Express manages objects during their lifetime.",
   ).optional(),
   Tags: z.array(TagSchema).optional(),
-  LocationName: z.string().describe(
-    "Specifies the Zone ID of the Availability Zone or Local Zone where the directory bucket will be created. An example Availability Zone ID value is 'use1-az5'.",
-  ),
+  MetricsConfigurations: z.array(MetricsConfigurationSchema).describe(
+    "Specifies the metrics configurations for the Amazon S3 Express bucket.",
+  ).optional(),
 });
 
 const StateSchema = z.object({
   BucketName: z.string(),
+  LocationName: z.string().optional(),
+  AvailabilityZoneName: z.string().optional(),
+  DataRedundancy: z.string().optional(),
+  Arn: z.string().optional(),
   BucketEncryption: z.object({
     ServerSideEncryptionConfiguration: z.array(ServerSideEncryptionRuleSchema),
   }).optional(),
-  AvailabilityZoneName: z.string().optional(),
-  DataRedundancy: z.string().optional(),
   LifecycleConfiguration: z.object({
     Rules: z.array(RuleSchema),
   }).optional(),
-  Arn: z.string().optional(),
   Tags: z.array(TagSchema).optional(),
-  LocationName: z.string().optional(),
+  MetricsConfigurations: z.array(MetricsConfigurationSchema).optional(),
 }).passthrough();
 
 type StateData = z.infer<typeof StateSchema>;
@@ -108,6 +123,13 @@ const InputsSchema = z.object({
   ).describe(
     "Specifies a name for the bucket. The bucket name must contain only lowercase letters, numbers, and hyphens (-). A directory bucket name must be unique in the chosen Availability Zone or Local Zone. The bucket name must also follow the format 'bucket_base_name--zone_id--x-s3'. The zone_id can be the ID of an Availability Zone or a Local Zone. If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the bucket name.",
   ).optional(),
+  LocationName: z.string().describe(
+    "Specifies the Zone ID of the Availability Zone or Local Zone where the directory bucket will be created. An example Availability Zone ID value is 'use1-az5'.",
+  ).optional(),
+  DataRedundancy: z.enum(["SingleAvailabilityZone", "SingleLocalZone"])
+    .describe(
+      "Specifies the number of Availability Zone or Local Zone that's used for redundancy for the bucket.",
+    ).optional(),
   BucketEncryption: z.object({
     ServerSideEncryptionConfiguration: z.array(ServerSideEncryptionRuleSchema)
       .describe("Specifies the default server-side-encryption configuration.")
@@ -115,10 +137,6 @@ const InputsSchema = z.object({
   }).describe(
     "Specifies default encryption for a bucket using server-side encryption with Amazon S3 managed keys (SSE-S3) or AWS KMS keys (SSE-KMS).",
   ).optional(),
-  DataRedundancy: z.enum(["SingleAvailabilityZone", "SingleLocalZone"])
-    .describe(
-      "Specifies the number of Availability Zone or Local Zone that's used for redundancy for the bucket.",
-    ).optional(),
   LifecycleConfiguration: z.object({
     Rules: z.array(RuleSchema).describe(
       "A lifecycle rule for individual objects in an Amazon S3 Express bucket.",
@@ -127,14 +145,14 @@ const InputsSchema = z.object({
     "Lifecycle rules that define how Amazon S3 Express manages objects during their lifetime.",
   ).optional(),
   Tags: z.array(TagSchema).optional(),
-  LocationName: z.string().describe(
-    "Specifies the Zone ID of the Availability Zone or Local Zone where the directory bucket will be created. An example Availability Zone ID value is 'use1-az5'.",
+  MetricsConfigurations: z.array(MetricsConfigurationSchema).describe(
+    "Specifies the metrics configurations for the Amazon S3 Express bucket.",
   ).optional(),
 });
 
 export const model = {
   type: "@swamp/aws/s3express/directory-bucket",
-  version: "2026.04.03.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -149,6 +167,11 @@ export const model = {
     {
       toVersion: "2026.04.03.2",
       description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
+      description: "Added: MetricsConfigurations",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
   ],

--- a/model/aws/s3express/manifest.yaml
+++ b/model/aws/s3express/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/s3express"
-version: "2026.04.03.2"
+version: "2026.04.07.1"
 description: "AWS S3EXPRESS infrastructure models"
 labels:
   - aws
@@ -9,7 +9,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: access_point, bucket_policy, directory_bucket
+  - Updated: directory_bucket
 models:
   - access_point.ts
   - bucket_policy.ts

--- a/model/aws/s3tables/extensions/models/table.ts
+++ b/model/aws/s3tables/extensions/models/table.ts
@@ -44,6 +44,30 @@ export const IcebergSortOrderSchema = z.object({
   ).optional(),
 });
 
+export const SchemaV2FieldSchema = z.object({
+  Required: z.boolean().describe(
+    "A Boolean value that specifies whether values are required for each row in this field",
+  ),
+  Doc: z.string().describe("Optional documentation for the field").optional(),
+  Id: z.number().int().describe("The unique identifier for the field"),
+  Name: z.string().describe("The name of the field"),
+});
+
+export const IcebergSchemaV2Schema = z.object({
+  SchemaV2FieldList: z.array(SchemaV2FieldSchema).describe(
+    "The schema fields for the table",
+  ),
+  SchemaV2FieldType: z.enum(["struct"]).describe(
+    "The type of the top-level schema, which is always 'struct'",
+  ),
+  SchemaId: z.number().int().describe(
+    "An optional unique identifier for the schema",
+  ).optional(),
+  IdentifierFieldIds: z.array(z.number().int()).describe(
+    "A list of field IDs that are used as the identifier fields for the table. Identifier fields uniquely identify a row in the table.",
+  ).optional(),
+});
+
 export const IcebergPartitionFieldSchema = z.object({
   SourceId: z.number().int().describe("The source column ID to partition on"),
   FieldId: z.number().int().describe(
@@ -103,10 +127,13 @@ const GlobalArgsSchema = z.object({
   OpenTableFormat: z.enum(["ICEBERG"]).describe("Format of the table."),
   IcebergMetadata: z.object({
     IcebergSchema: IcebergSchemaSchema.describe(
-      "Contains details about the schema for an Iceberg table",
-    ),
+      "Schema definition for flat tables with primitive types only. Mutually exclusive with IcebergSchemaV2.",
+    ).optional(),
     IcebergSortOrder: IcebergSortOrderSchema.describe(
       "Sort order specification for an Iceberg table",
+    ).optional(),
+    IcebergSchemaV2: IcebergSchemaV2Schema.describe(
+      "Schema definition that supports Apache Iceberg nested types (struct, list, map) and primitive types. Mutually exclusive with IcebergSchema.",
     ).optional(),
     IcebergPartitionSpec: IcebergPartitionSpecSchema.describe(
       "Partition specification for an Iceberg table",
@@ -114,8 +141,9 @@ const GlobalArgsSchema = z.object({
     TableProperties: z.record(z.string(), z.string()).describe(
       "Iceberg table properties (e.g., format-version, write.parquet.compression-codec)",
     ).optional(),
-  }).describe("Contains details about the metadata for an Iceberg table.")
-    .optional(),
+  }).describe(
+    "Contains details about the metadata for an Iceberg table. Specify either IcebergSchema (for simple flat schemas with primitive types only) or IcebergSchemaV2 (for schemas with nested types like struct, list, map), but not both.",
+  ).optional(),
   SnapshotManagement: z.object({
     Status: z.enum(["enabled", "disabled"]).describe(
       "Indicates whether the SnapshotManagement maintenance action is enabled.",
@@ -152,6 +180,7 @@ const StateSchema = z.object({
   IcebergMetadata: z.object({
     IcebergSchema: IcebergSchemaSchema,
     IcebergSortOrder: IcebergSortOrderSchema,
+    IcebergSchemaV2: IcebergSchemaV2Schema,
     IcebergPartitionSpec: IcebergPartitionSpecSchema,
     TableProperties: z.record(z.string(), z.unknown()),
   }).optional(),
@@ -196,10 +225,13 @@ const InputsSchema = z.object({
     .optional(),
   IcebergMetadata: z.object({
     IcebergSchema: IcebergSchemaSchema.describe(
-      "Contains details about the schema for an Iceberg table",
+      "Schema definition for flat tables with primitive types only. Mutually exclusive with IcebergSchemaV2.",
     ).optional(),
     IcebergSortOrder: IcebergSortOrderSchema.describe(
       "Sort order specification for an Iceberg table",
+    ).optional(),
+    IcebergSchemaV2: IcebergSchemaV2Schema.describe(
+      "Schema definition that supports Apache Iceberg nested types (struct, list, map) and primitive types. Mutually exclusive with IcebergSchema.",
     ).optional(),
     IcebergPartitionSpec: IcebergPartitionSpecSchema.describe(
       "Partition specification for an Iceberg table",
@@ -207,8 +239,9 @@ const InputsSchema = z.object({
     TableProperties: z.record(z.string(), z.string()).describe(
       "Iceberg table properties (e.g., format-version, write.parquet.compression-codec)",
     ).optional(),
-  }).describe("Contains details about the metadata for an Iceberg table.")
-    .optional(),
+  }).describe(
+    "Contains details about the metadata for an Iceberg table. Specify either IcebergSchema (for simple flat schemas with primitive types only) or IcebergSchemaV2 (for schemas with nested types like struct, list, map), but not both.",
+  ).optional(),
   SnapshotManagement: z.object({
     Status: z.enum(["enabled", "disabled"]).describe(
       "Indicates whether the SnapshotManagement maintenance action is enabled.",
@@ -229,7 +262,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/s3tables/table",
-  version: "2026.04.03.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -243,6 +276,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.03.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/s3tables/extensions/models/table_bucket.ts
+++ b/model/aws/s3tables/extensions/models/table_bucket.ts
@@ -12,6 +12,18 @@ import {
   updateResource,
 } from "./_lib/aws.ts";
 
+export const ReplicationDestinationSchema = z.object({
+  DestinationTableBucketARN: z.string().describe(
+    "The ARN of the destination table bucket",
+  ),
+});
+
+export const ReplicationRuleSchema = z.object({
+  Destinations: z.array(ReplicationDestinationSchema).describe(
+    "List of replication destinations",
+  ),
+});
+
 export const TagSchema = z.object({
   Key: z.string().min(1).max(128).describe(
     "Tag key must be between 1 to 128 characters in length. Tag key cannot start with 'aws:' and can only contain alphanumeric characters, spaces, _,., /, =, +, -, and @.",
@@ -61,6 +73,11 @@ const GlobalArgsSchema = z.object({
     ).optional(),
   }).describe("Specifies storage class settings for the table bucket")
     .optional(),
+  ReplicationConfiguration: z.object({
+    Role: z.string().describe("The ARN of the IAM role to use for replication"),
+    Rules: z.array(ReplicationRuleSchema).describe("List of replication rules"),
+  }).describe("Specifies replication configuration for the table bucket")
+    .optional(),
   Tags: z.array(TagSchema).describe(
     "User tags (key-value pairs) to associate with the table bucket.",
   ).optional(),
@@ -83,6 +100,10 @@ const StateSchema = z.object({
   }).optional(),
   StorageClassConfiguration: z.object({
     StorageClass: z.string(),
+  }).optional(),
+  ReplicationConfiguration: z.object({
+    Role: z.string(),
+    Rules: z.array(ReplicationRuleSchema),
   }).optional(),
   Tags: z.array(TagSchema).optional(),
 }).passthrough();
@@ -127,6 +148,13 @@ const InputsSchema = z.object({
     ).optional(),
   }).describe("Specifies storage class settings for the table bucket")
     .optional(),
+  ReplicationConfiguration: z.object({
+    Role: z.string().describe("The ARN of the IAM role to use for replication")
+      .optional(),
+    Rules: z.array(ReplicationRuleSchema).describe("List of replication rules")
+      .optional(),
+  }).describe("Specifies replication configuration for the table bucket")
+    .optional(),
   Tags: z.array(TagSchema).describe(
     "User tags (key-value pairs) to associate with the table bucket.",
   ).optional(),
@@ -134,7 +162,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/s3tables/table-bucket",
-  version: "2026.04.03.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -149,6 +177,11 @@ export const model = {
     {
       toVersion: "2026.04.03.2",
       description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
+      description: "Added: ReplicationConfiguration",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
   ],

--- a/model/aws/s3tables/manifest.yaml
+++ b/model/aws/s3tables/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/s3tables"
-version: "2026.04.03.2"
+version: "2026.04.07.1"
 description: "AWS S3TABLES infrastructure models"
 labels:
   - aws
@@ -9,7 +9,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: namespace, table, table_bucket, table_bucket_policy, table_policy
+  - Updated: table, table_bucket
 models:
   - namespace.ts
   - table.ts

--- a/model/aws/sso/extensions/models/assignment.ts
+++ b/model/aws/sso/extensions/models/assignment.ts
@@ -17,7 +17,7 @@ const GlobalArgsSchema = z.object({
   ),
   InstanceArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}",
+      "arn:aws(-[a-z]{1,5}){0,3}:sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}",
     ),
   ).describe("The sso instance that the permission set is owned."),
   TargetId: z.string().regex(new RegExp("\\d{12}")).describe(
@@ -28,7 +28,7 @@ const GlobalArgsSchema = z.object({
   ),
   PermissionSetArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso:::permissionSet/(sso)?ins-[a-zA-Z0-9-.]{16}/ps-[a-zA-Z0-9-./]{16}",
+      "arn:aws(-[a-z]{1,5}){0,3}:sso:::permissionSet/(sso)?ins-[a-zA-Z0-9-.]{16}/ps-[a-zA-Z0-9-./]{16}",
     ),
   ).describe("The permission set that the assignment will be assigned"),
   PrincipalType: z.enum(["USER", "GROUP"]).describe(
@@ -56,7 +56,7 @@ const InputsSchema = z.object({
   name: z.string().optional(),
   InstanceArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}",
+      "arn:aws(-[a-z]{1,5}){0,3}:sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}",
     ),
   ).describe("The sso instance that the permission set is owned.").optional(),
   TargetId: z.string().regex(new RegExp("\\d{12}")).describe(
@@ -67,7 +67,7 @@ const InputsSchema = z.object({
   ).optional(),
   PermissionSetArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso:::permissionSet/(sso)?ins-[a-zA-Z0-9-.]{16}/ps-[a-zA-Z0-9-./]{16}",
+      "arn:aws(-[a-z]{1,5}){0,3}:sso:::permissionSet/(sso)?ins-[a-zA-Z0-9-.]{16}/ps-[a-zA-Z0-9-./]{16}",
     ),
   ).describe("The permission set that the assignment will be assigned")
     .optional(),
@@ -83,7 +83,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/sso/assignment",
-  version: "2026.04.03.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -97,6 +97,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.03.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/sso/extensions/models/instance_access_control_attribute_configuration.ts
+++ b/model/aws/sso/extensions/models/instance_access_control_attribute_configuration.ts
@@ -30,7 +30,7 @@ export const AccessControlAttributeSchema = z.object({
 const GlobalArgsSchema = z.object({
   InstanceArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}",
+      "arn:aws(-[a-z]{1,5}){0,3}:sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}",
     ),
   ).describe(
     "The ARN of the AWS SSO instance under which the operation will be executed.",
@@ -56,7 +56,7 @@ type StateData = z.infer<typeof StateSchema>;
 const InputsSchema = z.object({
   InstanceArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}",
+      "arn:aws(-[a-z]{1,5}){0,3}:sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}",
     ),
   ).describe(
     "The ARN of the AWS SSO instance under which the operation will be executed.",
@@ -71,7 +71,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/sso/instance-access-control-attribute-configuration",
-  version: "2026.04.03.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -85,6 +85,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.03.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/sso/extensions/models/permission_set.ts
+++ b/model/aws/sso/extensions/models/permission_set.ts
@@ -36,7 +36,7 @@ const GlobalArgsSchema = z.object({
   ).describe("The permission set description.").optional(),
   InstanceArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}",
+      "arn:aws(-[a-z]{1,5}){0,3}:sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}",
     ),
   ).describe("The sso instance arn that the permission set is owned."),
   SessionDuration: z.string().min(1).max(100).regex(
@@ -99,7 +99,7 @@ const InputsSchema = z.object({
   ).describe("The permission set description.").optional(),
   InstanceArn: z.string().min(10).max(1224).regex(
     new RegExp(
-      "arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}",
+      "arn:aws(-[a-z]{1,5}){0,3}:sso:::instance/(sso)?ins-[a-zA-Z0-9-.]{16}",
     ),
   ).describe("The sso instance arn that the permission set is owned.")
     .optional(),
@@ -135,7 +135,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/sso/permission-set",
-  version: "2026.04.03.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -149,6 +149,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.03.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/aws/sso/manifest.yaml
+++ b/model/aws/sso/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/sso"
-version: "2026.04.03.3"
+version: "2026.04.07.1"
 description: "AWS SSO infrastructure models"
 labels:
   - aws
@@ -9,7 +9,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: application, application_assignment, assignment, instance, instance_access_control_attribute_configuration, permission_set
+  - Updated: assignment, instance_access_control_attribute_configuration, permission_set
 models:
   - application.ts
   - application_assignment.ts

--- a/model/aws/stepfunctions/extensions/models/state_machine_alias.ts
+++ b/model/aws/stepfunctions/extensions/models/state_machine_alias.ts
@@ -25,6 +25,7 @@ const GlobalArgsSchema = z.object({
   name: z.string().describe(
     "Instance name for this resource (used as the unique identifier in the factory pattern)",
   ),
+  StateMachineArn: z.string().min(1).max(2048).optional(),
   Name: z.string().min(1).max(80).describe("The alias name.").optional(),
   Description: z.string().min(1).max(256).describe(
     "An optional description of the alias.",
@@ -52,6 +53,7 @@ const GlobalArgsSchema = z.object({
 
 const StateSchema = z.object({
   Arn: z.string(),
+  StateMachineArn: z.string().optional(),
   Name: z.string().optional(),
   Description: z.string().optional(),
   RoutingConfiguration: z.array(RoutingConfigurationVersionSchema).optional(),
@@ -68,6 +70,7 @@ type StateData = z.infer<typeof StateSchema>;
 
 const InputsSchema = z.object({
   name: z.string().optional(),
+  StateMachineArn: z.string().min(1).max(2048).optional(),
   Name: z.string().min(1).max(80).describe("The alias name.").optional(),
   Description: z.string().min(1).max(256).describe(
     "An optional description of the alias.",
@@ -95,7 +98,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/aws/stepfunctions/state-machine-alias",
-  version: "2026.04.03.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -110,6 +113,11 @@ export const model = {
     {
       toVersion: "2026.04.03.2",
       description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
+      description: "Added: StateMachineArn",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
   ],

--- a/model/aws/stepfunctions/manifest.yaml
+++ b/model/aws/stepfunctions/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/aws/stepfunctions"
-version: "2026.04.03.2"
+version: "2026.04.07.1"
 description: "AWS STEPFUNCTIONS infrastructure models"
 labels:
   - aws
@@ -9,7 +9,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: activity, state_machine, state_machine_alias, state_machine_version
+  - Updated: state_machine_alias
 models:
   - activity.ts
   - state_machine.ts

--- a/model/gcp/accesscontextmanager/extensions/models/accesspolicies_serviceperimeters.ts
+++ b/model/gcp/accesscontextmanager/extensions/models/accesspolicies_serviceperimeters.ts
@@ -101,7 +101,7 @@ const GlobalArgsSchema = z.object({
     egressPolicies: z.array(z.object({
       egressFrom: z.object({
         identities: z.array(z.unknown()).describe(
-          "A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, or third-party identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
+          "A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
         ).optional(),
         identityType: z.enum([
           "IDENTITY_TYPE_UNSPECIFIED",
@@ -149,7 +149,7 @@ const GlobalArgsSchema = z.object({
     ingressPolicies: z.array(z.object({
       ingressFrom: z.object({
         identities: z.array(z.unknown()).describe(
-          "A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, or third-party identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
+          "A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
         ).optional(),
         identityType: z.enum([
           "IDENTITY_TYPE_UNSPECIFIED",
@@ -210,7 +210,7 @@ const GlobalArgsSchema = z.object({
     egressPolicies: z.array(z.object({
       egressFrom: z.object({
         identities: z.array(z.unknown()).describe(
-          "A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, or third-party identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
+          "A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
         ).optional(),
         identityType: z.enum([
           "IDENTITY_TYPE_UNSPECIFIED",
@@ -258,7 +258,7 @@ const GlobalArgsSchema = z.object({
     ingressPolicies: z.array(z.object({
       ingressFrom: z.object({
         identities: z.array(z.unknown()).describe(
-          "A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, or third-party identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
+          "A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
         ).optional(),
         identityType: z.enum([
           "IDENTITY_TYPE_UNSPECIFIED",
@@ -426,7 +426,7 @@ const InputsSchema = z.object({
     egressPolicies: z.array(z.object({
       egressFrom: z.object({
         identities: z.array(z.unknown()).describe(
-          "A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, or third-party identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
+          "A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
         ).optional(),
         identityType: z.enum([
           "IDENTITY_TYPE_UNSPECIFIED",
@@ -474,7 +474,7 @@ const InputsSchema = z.object({
     ingressPolicies: z.array(z.object({
       ingressFrom: z.object({
         identities: z.array(z.unknown()).describe(
-          "A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, or third-party identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
+          "A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
         ).optional(),
         identityType: z.enum([
           "IDENTITY_TYPE_UNSPECIFIED",
@@ -535,7 +535,7 @@ const InputsSchema = z.object({
     egressPolicies: z.array(z.object({
       egressFrom: z.object({
         identities: z.array(z.unknown()).describe(
-          "A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, or third-party identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
+          "A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
         ).optional(),
         identityType: z.enum([
           "IDENTITY_TYPE_UNSPECIFIED",
@@ -583,7 +583,7 @@ const InputsSchema = z.object({
     ingressPolicies: z.array(z.object({
       ingressFrom: z.object({
         identities: z.array(z.unknown()).describe(
-          "A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, or third-party identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
+          "A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities.",
         ).optional(),
         identityType: z.enum([
           "IDENTITY_TYPE_UNSPECIFIED",
@@ -650,7 +650,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/accesscontextmanager/accesspolicies-serviceperimeters",
-  version: "2026.04.04.1",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -689,6 +689,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/accesscontextmanager/manifest.yaml
+++ b/model/gcp/accesscontextmanager/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/gcp/accesscontextmanager"
-version: "2026.04.04.1"
+version: "2026.04.07.1"
 description: "Google Cloud accesscontextmanager infrastructure models"
 labels:
   - gcp
@@ -10,7 +10,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: accesspolicies_accesslevels, accesspolicies_serviceperimeters, gcpuseraccessbindings
+  - Updated: accesspolicies_serviceperimeters
 models:
   - accesspolicies.ts
   - accesspolicies_accesslevels.ts

--- a/model/gcp/agentregistry/extensions/models/agents.ts
+++ b/model/gcp/agentregistry/extensions/models/agents.ts
@@ -5,6 +5,7 @@
 
 import { z } from "zod";
 import {
+  createResource,
   getProjectId,
   isResourceNotFoundError,
   readResource,
@@ -84,7 +85,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/agentregistry/agents",
-  version: "2026.04.03.3",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -108,6 +109,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.03.3",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -202,6 +208,43 @@ export const model = {
           }
           throw error;
         }
+      },
+    },
+    search: {
+      description: "search",
+      arguments: z.object({
+        pageSize: z.any().optional(),
+        pageToken: z.any().optional(),
+        searchString: z.any().optional(),
+      }),
+      execute: async (args: Record<string, unknown>, context: any) => {
+        const g = context.globalArgs;
+        const projectId = await getProjectId();
+        const params: Record<string, string> = { project: projectId };
+        if (g["parent"] !== undefined) params["parent"] = String(g["parent"]);
+        const body: Record<string, unknown> = {};
+        if (args["pageSize"] !== undefined) body["pageSize"] = args["pageSize"];
+        if (args["pageToken"] !== undefined) {
+          body["pageToken"] = args["pageToken"];
+        }
+        if (args["searchString"] !== undefined) {
+          body["searchString"] = args["searchString"];
+        }
+        const result = await createResource(
+          BASE_URL,
+          {
+            "id": "agentregistry.projects.locations.agents.search",
+            "path": "v1alpha/{+parent}/agents:search",
+            "httpMethod": "POST",
+            "parameterOrder": ["parent"],
+            "parameters": {
+              "parent": { "location": "path", "required": true },
+            },
+          },
+          params,
+          body,
+        );
+        return { result };
       },
     },
   },

--- a/model/gcp/agentregistry/extensions/models/mcpservers.ts
+++ b/model/gcp/agentregistry/extensions/models/mcpservers.ts
@@ -5,6 +5,7 @@
 
 import { z } from "zod";
 import {
+  createResource,
   getProjectId,
   isResourceNotFoundError,
   readResource,
@@ -77,7 +78,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/agentregistry/mcpservers",
-  version: "2026.04.03.3",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -101,6 +102,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.03.3",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -194,6 +200,43 @@ export const model = {
           }
           throw error;
         }
+      },
+    },
+    search: {
+      description: "search",
+      arguments: z.object({
+        pageSize: z.any().optional(),
+        pageToken: z.any().optional(),
+        searchString: z.any().optional(),
+      }),
+      execute: async (args: Record<string, unknown>, context: any) => {
+        const g = context.globalArgs;
+        const projectId = await getProjectId();
+        const params: Record<string, string> = { project: projectId };
+        if (g["parent"] !== undefined) params["parent"] = String(g["parent"]);
+        const body: Record<string, unknown> = {};
+        if (args["pageSize"] !== undefined) body["pageSize"] = args["pageSize"];
+        if (args["pageToken"] !== undefined) {
+          body["pageToken"] = args["pageToken"];
+        }
+        if (args["searchString"] !== undefined) {
+          body["searchString"] = args["searchString"];
+        }
+        const result = await createResource(
+          BASE_URL,
+          {
+            "id": "agentregistry.projects.locations.mcpServers.search",
+            "path": "v1alpha/{+parent}/mcpServers:search",
+            "httpMethod": "POST",
+            "parameterOrder": ["parent"],
+            "parameters": {
+              "parent": { "location": "path", "required": true },
+            },
+          },
+          params,
+          body,
+        );
+        return { result };
       },
     },
   },

--- a/model/gcp/agentregistry/manifest.yaml
+++ b/model/gcp/agentregistry/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/gcp/agentregistry"
-version: "2026.04.03.3"
+version: "2026.04.07.1"
 description: "Google Cloud agentregistry infrastructure models"
 labels:
   - gcp
@@ -10,7 +10,7 @@ labels:
   - cloud
   - infrastructure
 releaseNotes: |
-  - Updated: locations, agents, endpoints, mcpservers, services
+  - Updated: agents, mcpservers
 models:
   - agents.ts
   - endpoints.ts

--- a/model/gcp/compute/extensions/models/backendbuckets.ts
+++ b/model/gcp/compute/extensions/models/backendbuckets.ts
@@ -176,9 +176,10 @@ const GlobalArgsSchema = z.object({
   enableCdn: z.boolean().describe(
     "If true, enable Cloud CDN for this BackendBucket.",
   ).optional(),
-  loadBalancingScheme: z.enum(["INTERNAL_MANAGED"]).describe(
-    "The value can only be INTERNAL_MANAGED for cross-region internal layer 7 load balancer. If loadBalancingScheme is not specified, the backend bucket can be used by classic global external load balancers, or global application external load balancers, or both.",
-  ).optional(),
+  loadBalancingScheme: z.enum(["EXTERNAL_MANAGED", "INTERNAL_MANAGED"])
+    .describe(
+      "The value can only be INTERNAL_MANAGED for cross-region internal layer 7 load balancer. If loadBalancingScheme is not specified, the backend bucket can be used by classic global external load balancers, or global application external load balancers, or both.",
+    ).optional(),
   name: z.string().regex(new RegExp("[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?"))
     .describe(
       "Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply withRFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.",
@@ -230,6 +231,7 @@ const StateSchema = z.object({
   params: z.object({
     resourceManagerTags: z.record(z.string(), z.unknown()),
   }).optional(),
+  region: z.string().optional(),
   selfLink: z.string().optional(),
   usedBy: z.array(z.object({
     reference: z.string(),
@@ -315,9 +317,10 @@ const InputsSchema = z.object({
   enableCdn: z.boolean().describe(
     "If true, enable Cloud CDN for this BackendBucket.",
   ).optional(),
-  loadBalancingScheme: z.enum(["INTERNAL_MANAGED"]).describe(
-    "The value can only be INTERNAL_MANAGED for cross-region internal layer 7 load balancer. If loadBalancingScheme is not specified, the backend bucket can be used by classic global external load balancers, or global application external load balancers, or both.",
-  ).optional(),
+  loadBalancingScheme: z.enum(["EXTERNAL_MANAGED", "INTERNAL_MANAGED"])
+    .describe(
+      "The value can only be INTERNAL_MANAGED for cross-region internal layer 7 load balancer. If loadBalancingScheme is not specified, the backend bucket can be used by classic global external load balancers, or global application external load balancers, or both.",
+    ).optional(),
   name: z.string().regex(new RegExp("[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?"))
     .describe(
       "Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply withRFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.",
@@ -334,7 +337,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/backendbuckets",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -378,6 +381,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -652,6 +660,34 @@ export const model = {
           },
           params,
           body,
+        );
+        return { result };
+      },
+    },
+    list_usable: {
+      description: "list usable",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, unknown>, _context: any) => {
+        const projectId = await getProjectId();
+        const params: Record<string, string> = { project: projectId };
+        const result = await createResource(
+          BASE_URL,
+          {
+            "id": "compute.backendBuckets.listUsable",
+            "path": "projects/{project}/global/backendBuckets/listUsable",
+            "httpMethod": "GET",
+            "parameterOrder": ["project"],
+            "parameters": {
+              "filter": { "location": "query" },
+              "maxResults": { "location": "query" },
+              "orderBy": { "location": "query" },
+              "pageToken": { "location": "query" },
+              "project": { "location": "path", "required": true },
+              "returnPartialSuccess": { "location": "query" },
+            },
+          },
+          params,
+          {},
         );
         return { result };
       },

--- a/model/gcp/compute/extensions/models/backendservices.ts
+++ b/model/gcp/compute/extensions/models/backendservices.ts
@@ -107,6 +107,7 @@ const GlobalArgsSchema = z.object({
     balancingMode: z.enum([
       "CONNECTION",
       "CUSTOM_METRICS",
+      "IN_FLIGHT",
       "RATE",
       "UTILIZATION",
     ]).describe(
@@ -146,6 +147,15 @@ const GlobalArgsSchema = z.object({
     maxConnectionsPerInstance: z.number().int().describe(
       "Defines a target maximum number of simultaneous connections. For usage guidelines, seeConnection balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isRATE.",
     ).optional(),
+    maxInFlightRequests: z.number().int().describe(
+      "Defines a maximum number of in-flight requests for the whole NEG or instance group. Not available if backend's balancingMode isRATE or CONNECTION.",
+    ).optional(),
+    maxInFlightRequestsPerEndpoint: z.number().int().describe(
+      "Defines a maximum number of in-flight requests for a single endpoint. Not available if backend's balancingMode is RATE or CONNECTION.",
+    ).optional(),
+    maxInFlightRequestsPerInstance: z.number().int().describe(
+      "Defines a maximum number of in-flight requests for a single VM. Not available if backend's balancingMode is RATE or CONNECTION.",
+    ).optional(),
     maxRate: z.number().int().describe(
       "Defines a maximum number of HTTP requests per second (RPS). For usage guidelines, seeRate balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isCONNECTION.",
     ).optional(),
@@ -169,6 +179,8 @@ const GlobalArgsSchema = z.object({
       .describe(
         "This field indicates whether this backend should be fully utilized before sending traffic to backends with default preference. The possible values are: - PREFERRED: Backends with this preference level will be filled up to their capacity limits first, based on RTT. - DEFAULT: If preferred backends don't have enough capacity, backends in this layer would be used and traffic would be assigned based on the load balancing algorithm you use. This is the default",
       ).optional(),
+    trafficDuration: z.enum(["LONG", "SHORT", "TRAFFIC_DURATION_UNSPECIFIED"])
+      .optional(),
   })).describe("The list of backends that serve this BackendService.")
     .optional(),
   cdnPolicy: z.object({
@@ -467,7 +479,7 @@ const GlobalArgsSchema = z.object({
     "WEIGHTED_MAGLEV",
     "WEIGHTED_ROUND_ROBIN",
   ]).describe(
-    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
+    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
   ).optional(),
   logConfig: z.object({
     enable: z.boolean().describe(
@@ -707,6 +719,9 @@ const StateSchema = z.object({
     maxConnections: z.number(),
     maxConnectionsPerEndpoint: z.number(),
     maxConnectionsPerInstance: z.number(),
+    maxInFlightRequests: z.number(),
+    maxInFlightRequestsPerEndpoint: z.number(),
+    maxInFlightRequestsPerInstance: z.number(),
     maxRate: z.number(),
     maxRatePerEndpoint: z.number(),
     maxRatePerInstance: z.number(),
@@ -715,6 +730,7 @@ const StateSchema = z.object({
       resourceUri: z.string(),
     }),
     preference: z.string(),
+    trafficDuration: z.string(),
   })).optional(),
   cdnPolicy: z.object({
     bypassCacheOnRequestHeaders: z.array(z.object({
@@ -918,6 +934,7 @@ const InputsSchema = z.object({
     balancingMode: z.enum([
       "CONNECTION",
       "CUSTOM_METRICS",
+      "IN_FLIGHT",
       "RATE",
       "UTILIZATION",
     ]).describe(
@@ -957,6 +974,15 @@ const InputsSchema = z.object({
     maxConnectionsPerInstance: z.number().int().describe(
       "Defines a target maximum number of simultaneous connections. For usage guidelines, seeConnection balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isRATE.",
     ).optional(),
+    maxInFlightRequests: z.number().int().describe(
+      "Defines a maximum number of in-flight requests for the whole NEG or instance group. Not available if backend's balancingMode isRATE or CONNECTION.",
+    ).optional(),
+    maxInFlightRequestsPerEndpoint: z.number().int().describe(
+      "Defines a maximum number of in-flight requests for a single endpoint. Not available if backend's balancingMode is RATE or CONNECTION.",
+    ).optional(),
+    maxInFlightRequestsPerInstance: z.number().int().describe(
+      "Defines a maximum number of in-flight requests for a single VM. Not available if backend's balancingMode is RATE or CONNECTION.",
+    ).optional(),
     maxRate: z.number().int().describe(
       "Defines a maximum number of HTTP requests per second (RPS). For usage guidelines, seeRate balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isCONNECTION.",
     ).optional(),
@@ -980,6 +1006,8 @@ const InputsSchema = z.object({
       .describe(
         "This field indicates whether this backend should be fully utilized before sending traffic to backends with default preference. The possible values are: - PREFERRED: Backends with this preference level will be filled up to their capacity limits first, based on RTT. - DEFAULT: If preferred backends don't have enough capacity, backends in this layer would be used and traffic would be assigned based on the load balancing algorithm you use. This is the default",
       ).optional(),
+    trafficDuration: z.enum(["LONG", "SHORT", "TRAFFIC_DURATION_UNSPECIFIED"])
+      .optional(),
   })).describe("The list of backends that serve this BackendService.")
     .optional(),
   cdnPolicy: z.object({
@@ -1278,7 +1306,7 @@ const InputsSchema = z.object({
     "WEIGHTED_MAGLEV",
     "WEIGHTED_ROUND_ROBIN",
   ]).describe(
-    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
+    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
   ).optional(),
   logConfig: z.object({
     enable: z.boolean().describe(
@@ -1504,7 +1532,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/backendservices",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1548,6 +1576,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/disks.ts
+++ b/model/gcp/compute/extensions/models/disks.ts
@@ -191,7 +191,7 @@ const GlobalArgsSchema = z.object({
       "VIRTIO_SCSI_MULTIQUEUE",
       "WINDOWS",
     ]).describe(
-      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
     ).optional(),
   })).describe(
     "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -477,7 +477,7 @@ const InputsSchema = z.object({
       "VIRTIO_SCSI_MULTIQUEUE",
       "WINDOWS",
     ]).describe(
-      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
     ).optional(),
   })).describe(
     "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -615,7 +615,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/disks",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -659,6 +659,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -1087,6 +1092,8 @@ export const model = {
     bulk_insert: {
       description: "bulk insert",
       arguments: z.object({
+        instantSnapshotGroupParameters: z.any().optional(),
+        snapshotGroupParameters: z.any().optional(),
         sourceConsistencyGroupPolicy: z.any().optional(),
       }),
       execute: async (args: Record<string, unknown>, context: any) => {
@@ -1095,6 +1102,13 @@ export const model = {
         const params: Record<string, string> = { project: projectId };
         if (g["zone"] !== undefined) params["zone"] = String(g["zone"]);
         const body: Record<string, unknown> = {};
+        if (args["instantSnapshotGroupParameters"] !== undefined) {
+          body["instantSnapshotGroupParameters"] =
+            args["instantSnapshotGroupParameters"];
+        }
+        if (args["snapshotGroupParameters"] !== undefined) {
+          body["snapshotGroupParameters"] = args["snapshotGroupParameters"];
+        }
         if (args["sourceConsistencyGroupPolicy"] !== undefined) {
           body["sourceConsistencyGroupPolicy"] =
             args["sourceConsistencyGroupPolicy"];
@@ -1173,10 +1187,13 @@ export const model = {
         locationHint: z.any().optional(),
         name: z.any().optional(),
         params: z.any().optional(),
+        region: z.any().optional(),
         satisfiesPzi: z.any().optional(),
         satisfiesPzs: z.any().optional(),
         selfLink: z.any().optional(),
         snapshotEncryptionKey: z.any().optional(),
+        snapshotGroupId: z.any().optional(),
+        snapshotGroupName: z.any().optional(),
         snapshotType: z.any().optional(),
         sourceDisk: z.any().optional(),
         sourceDiskEncryptionKey: z.any().optional(),
@@ -1260,6 +1277,7 @@ export const model = {
         }
         if (args["name"] !== undefined) body["name"] = args["name"];
         if (args["params"] !== undefined) body["params"] = args["params"];
+        if (args["region"] !== undefined) body["region"] = args["region"];
         if (args["satisfiesPzi"] !== undefined) {
           body["satisfiesPzi"] = args["satisfiesPzi"];
         }
@@ -1269,6 +1287,12 @@ export const model = {
         if (args["selfLink"] !== undefined) body["selfLink"] = args["selfLink"];
         if (args["snapshotEncryptionKey"] !== undefined) {
           body["snapshotEncryptionKey"] = args["snapshotEncryptionKey"];
+        }
+        if (args["snapshotGroupId"] !== undefined) {
+          body["snapshotGroupId"] = args["snapshotGroupId"];
+        }
+        if (args["snapshotGroupName"] !== undefined) {
+          body["snapshotGroupName"] = args["snapshotGroupName"];
         }
         if (args["snapshotType"] !== undefined) {
           body["snapshotType"] = args["snapshotType"];
@@ -1548,6 +1572,54 @@ export const model = {
             "httpMethod": "POST",
             "parameterOrder": ["project", "zone"],
             "parameters": {
+              "project": { "location": "path", "required": true },
+              "requestId": { "location": "query" },
+              "zone": { "location": "path", "required": true },
+            },
+          },
+          params,
+          body,
+        );
+        return { result };
+      },
+    },
+    update_kms_key: {
+      description: "update kms key",
+      arguments: z.object({
+        kmsKeyName: z.any().optional(),
+      }),
+      execute: async (args: Record<string, unknown>, context: any) => {
+        const g = context.globalArgs;
+        const projectId = await getProjectId();
+        const params: Record<string, string> = { project: projectId };
+        if (g["zone"] !== undefined) params["zone"] = String(g["zone"]);
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          (g.name?.toString() ?? "current").replace(/[\/\\]/g, "_").replace(
+            /\.\./g,
+            "_",
+          ).replace(/\0/g, ""),
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        params["disk"] = existing["name"]?.toString() ??
+          g["name"]?.toString() ?? "";
+        const body: Record<string, unknown> = {};
+        if (args["kmsKeyName"] !== undefined) {
+          body["kmsKeyName"] = args["kmsKeyName"];
+        }
+        const result = await createResource(
+          BASE_URL,
+          {
+            "id": "compute.disks.updateKmsKey",
+            "path": "projects/{project}/zones/{zone}/disks/{disk}/updateKmsKey",
+            "httpMethod": "POST",
+            "parameterOrder": ["project", "zone", "disk"],
+            "parameters": {
+              "disk": { "location": "path", "required": true },
               "project": { "location": "path", "required": true },
               "requestId": { "location": "query" },
               "zone": { "location": "path", "required": true },

--- a/model/gcp/compute/extensions/models/futurereservations.ts
+++ b/model/gcp/compute/extensions/models/futurereservations.ts
@@ -199,6 +199,10 @@ const GlobalArgsSchema = z.object({
       "Only applicable if FR is delivering to the same reservation. If set, all parent commitments will be extended to match the end date of the plan for this commitment.",
     ).optional(),
   }).optional(),
+  confidentialComputeType: z.enum([
+    "CONFIDENTIAL_COMPUTE_TYPE_TDX",
+    "CONFIDENTIAL_COMPUTE_TYPE_UNSPECIFIED",
+  ]).optional(),
   deploymentType: z.enum(["DENSE", "DEPLOYMENT_TYPE_UNSPECIFIED"]).describe(
     "Type of the deployment requested as part of future reservation.",
   ).optional(),
@@ -215,6 +219,11 @@ const GlobalArgsSchema = z.object({
   namePrefix: z.string().describe(
     "Name prefix for the reservations to be created at the time of delivery. The name prefix must comply with RFC1035. Maximum allowed length for name prefix is 20. Automatically created reservations name format will be -date-####.",
   ).optional(),
+  params: z.object({
+    resourceManagerTags: z.record(z.string(), z.string()).describe(
+      "Input only. Resource manager tags to be bound to the future reservation. Tag keys and values have the same definition as resource manager tags. Keys and values can be either in numeric format, such as `tagKeys/{tag_key_id}` and `tagValues/{tag_value_id}` or in namespaced format such as `{org_id|project_id}/{tag_key_short_name}` and `{tag_value_short_name}`. The field is ignored (both PUT & PATCH) when empty.",
+    ).optional(),
+  }).describe("Additional future reservation params.").optional(),
   planningStatus: z.enum(["DRAFT", "PLANNING_STATUS_UNSPECIFIED", "SUBMITTED"])
     .describe("Planning state before being submitted for evaluation")
     .optional(),
@@ -346,6 +355,7 @@ const StateSchema = z.object({
     commitmentPlan: z.string(),
     previousCommitmentTerms: z.string(),
   }).optional(),
+  confidentialComputeType: z.string().optional(),
   creationTimestamp: z.string().optional(),
   deploymentType: z.string().optional(),
   description: z.string().optional(),
@@ -354,6 +364,9 @@ const StateSchema = z.object({
   kind: z.string().optional(),
   name: z.string(),
   namePrefix: z.string().optional(),
+  params: z.object({
+    resourceManagerTags: z.record(z.string(), z.unknown()),
+  }).optional(),
   planningStatus: z.string().optional(),
   reservationMode: z.string().optional(),
   reservationName: z.string().optional(),
@@ -518,6 +531,10 @@ const InputsSchema = z.object({
       "Only applicable if FR is delivering to the same reservation. If set, all parent commitments will be extended to match the end date of the plan for this commitment.",
     ).optional(),
   }).optional(),
+  confidentialComputeType: z.enum([
+    "CONFIDENTIAL_COMPUTE_TYPE_TDX",
+    "CONFIDENTIAL_COMPUTE_TYPE_UNSPECIFIED",
+  ]).optional(),
   deploymentType: z.enum(["DENSE", "DEPLOYMENT_TYPE_UNSPECIFIED"]).describe(
     "Type of the deployment requested as part of future reservation.",
   ).optional(),
@@ -534,6 +551,11 @@ const InputsSchema = z.object({
   namePrefix: z.string().describe(
     "Name prefix for the reservations to be created at the time of delivery. The name prefix must comply with RFC1035. Maximum allowed length for name prefix is 20. Automatically created reservations name format will be -date-####.",
   ).optional(),
+  params: z.object({
+    resourceManagerTags: z.record(z.string(), z.string()).describe(
+      "Input only. Resource manager tags to be bound to the future reservation. Tag keys and values have the same definition as resource manager tags. Keys and values can be either in numeric format, such as `tagKeys/{tag_key_id}` and `tagValues/{tag_value_id}` or in namespaced format such as `{org_id|project_id}/{tag_key_short_name}` and `{tag_value_short_name}`. The field is ignored (both PUT & PATCH) when empty.",
+    ).optional(),
+  }).describe("Additional future reservation params.").optional(),
   planningStatus: z.enum(["DRAFT", "PLANNING_STATUS_UNSPECIFIED", "SUBMITTED"])
     .describe("Planning state before being submitted for evaluation")
     .optional(),
@@ -639,7 +661,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/futurereservations",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -700,6 +722,11 @@ export const model = {
         return rest;
       },
     },
+    {
+      toVersion: "2026.04.07.1",
+      description: "Added: confidentialComputeType, params",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
@@ -740,6 +767,9 @@ export const model = {
         if (g["commitmentInfo"] !== undefined) {
           body["commitmentInfo"] = g["commitmentInfo"];
         }
+        if (g["confidentialComputeType"] !== undefined) {
+          body["confidentialComputeType"] = g["confidentialComputeType"];
+        }
         if (g["deploymentType"] !== undefined) {
           body["deploymentType"] = g["deploymentType"];
         }
@@ -751,6 +781,7 @@ export const model = {
         }
         if (g["name"] !== undefined) body["name"] = g["name"];
         if (g["namePrefix"] !== undefined) body["namePrefix"] = g["namePrefix"];
+        if (g["params"] !== undefined) body["params"] = g["params"];
         if (g["planningStatus"] !== undefined) {
           body["planningStatus"] = g["planningStatus"];
         }
@@ -866,6 +897,9 @@ export const model = {
         if (g["commitmentInfo"] !== undefined) {
           body["commitmentInfo"] = g["commitmentInfo"];
         }
+        if (g["confidentialComputeType"] !== undefined) {
+          body["confidentialComputeType"] = g["confidentialComputeType"];
+        }
         if (g["deploymentType"] !== undefined) {
           body["deploymentType"] = g["deploymentType"];
         }
@@ -877,6 +911,7 @@ export const model = {
         }
         if (g["name"] !== undefined) body["name"] = g["name"];
         if (g["namePrefix"] !== undefined) body["namePrefix"] = g["namePrefix"];
+        if (g["params"] !== undefined) body["params"] = g["params"];
         if (g["planningStatus"] !== undefined) {
           body["planningStatus"] = g["planningStatus"];
         }

--- a/model/gcp/compute/extensions/models/images.ts
+++ b/model/gcp/compute/extensions/models/images.ts
@@ -154,7 +154,7 @@ const GlobalArgsSchema = z.object({
       "VIRTIO_SCSI_MULTIQUEUE",
       "WINDOWS",
     ]).describe(
-      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
     ).optional(),
   })).describe(
     "A list of features to enable on the guest operating system. Applicable only for bootable images. To see a list of available options, see theguestOSfeatures[].type parameter.",
@@ -204,7 +204,7 @@ const GlobalArgsSchema = z.object({
       "[Deprecated] This field is deprecated. An optional SHA1 checksum of the disk image before unpackaging provided by the client when the disk image is created.",
     ).optional(),
     source: z.string().describe(
-      "The full Google Cloud Storage URL where the raw disk image archive is stored. The following are valid formats for the URL: - https://storage.googleapis.com/bucket_name/image_archive_name - https://storage.googleapis.com/bucket_name/folder_name/image_archive_name In order to create an image, you must provide the full or partial URL of one of the following: - The rawDisk.source URL - The sourceDisk URL - The sourceImage URL - The sourceSnapshot URL",
+      "The full Google Cloud Storage URL or Artifact Registry path where the raw disk image archive is stored. The following are valid formats: - https://storage.googleapis.com/bucket_name/image_archive_name - https://storage.googleapis.com/bucket_name/folder_name/image_archive_name - projects/project/locations/location/repositories/repo/packages/package/versions/version_id - projects/project/locations/location/repositories/repo/packages/package/versions/version_id@dirsum_sha256:hex_value In order to create an image, you must provide the full or partial URL of one of the following: - The rawDisk.source URL - The sourceDisk URL - The sourceImage URL - The sourceSnapshot URL",
     ).optional(),
   }).describe("The parameters of the raw disk image.").optional(),
   shieldedInstanceInitialState: z.object({
@@ -458,7 +458,7 @@ const InputsSchema = z.object({
       "VIRTIO_SCSI_MULTIQUEUE",
       "WINDOWS",
     ]).describe(
-      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
     ).optional(),
   })).describe(
     "A list of features to enable on the guest operating system. Applicable only for bootable images. To see a list of available options, see theguestOSfeatures[].type parameter.",
@@ -508,7 +508,7 @@ const InputsSchema = z.object({
       "[Deprecated] This field is deprecated. An optional SHA1 checksum of the disk image before unpackaging provided by the client when the disk image is created.",
     ).optional(),
     source: z.string().describe(
-      "The full Google Cloud Storage URL where the raw disk image archive is stored. The following are valid formats for the URL: - https://storage.googleapis.com/bucket_name/image_archive_name - https://storage.googleapis.com/bucket_name/folder_name/image_archive_name In order to create an image, you must provide the full or partial URL of one of the following: - The rawDisk.source URL - The sourceDisk URL - The sourceImage URL - The sourceSnapshot URL",
+      "The full Google Cloud Storage URL or Artifact Registry path where the raw disk image archive is stored. The following are valid formats: - https://storage.googleapis.com/bucket_name/image_archive_name - https://storage.googleapis.com/bucket_name/folder_name/image_archive_name - projects/project/locations/location/repositories/repo/packages/package/versions/version_id - projects/project/locations/location/repositories/repo/packages/package/versions/version_id@dirsum_sha256:hex_value In order to create an image, you must provide the full or partial URL of one of the following: - The rawDisk.source URL - The sourceDisk URL - The sourceImage URL - The sourceSnapshot URL",
     ).optional(),
   }).describe("The parameters of the raw disk image.").optional(),
   shieldedInstanceInitialState: z.object({
@@ -617,7 +617,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/images",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -661,6 +661,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/instancegroupmanagerresizerequests.ts
+++ b/model/gcp/compute/extensions/models/instancegroupmanagerresizerequests.ts
@@ -147,7 +147,7 @@ const GlobalArgsSchema = z.object({
         "[Output Only] The array of errors encountered while processing this operation.",
       ).optional(),
     }).describe(
-      "Output only. [Output only] Fatal errors encountered during the queueing or provisioning phases of the ResizeRequest that caused the transition to the FAILED state. Contrary to the last_attempt errors, this field is final and errors are never removed from here, as the ResizeRequest is not going to retry.",
+      "Output only. Fatal errors encountered during the queueing or provisioning phases of the ResizeRequest that caused the transition to the FAILED state. Contrary to the last_attempt errors, this field is final and errors are never removed from here, as the ResizeRequest is not going to retry.",
     ).optional(),
     lastAttempt: z.object({
       error: z.object({
@@ -173,7 +173,7 @@ const GlobalArgsSchema = z.object({
     }).optional(),
   }).optional(),
   zone: z.string().describe(
-    "Output only. [Output Only] The URL of azone where the resize request is located. Populated only for zonal resize requests.",
+    "Output only. The URL of a zone where the resize request is located. Populated only for zonal resize requests.",
   ).optional(),
   instanceGroupManager: z.string().describe(
     "The name of the managed instance group to which the resize request will be added. Name should conform to RFC1035 or be a resource ID.",
@@ -189,6 +189,7 @@ const StateSchema = z.object({
   id: z.string().optional(),
   kind: z.string().optional(),
   name: z.string(),
+  region: z.string().optional(),
   requestedRunDuration: z.object({
     nanos: z.number(),
     seconds: z.string(),
@@ -261,7 +262,7 @@ const InputsSchema = z.object({
         "[Output Only] The array of errors encountered while processing this operation.",
       ).optional(),
     }).describe(
-      "Output only. [Output only] Fatal errors encountered during the queueing or provisioning phases of the ResizeRequest that caused the transition to the FAILED state. Contrary to the last_attempt errors, this field is final and errors are never removed from here, as the ResizeRequest is not going to retry.",
+      "Output only. Fatal errors encountered during the queueing or provisioning phases of the ResizeRequest that caused the transition to the FAILED state. Contrary to the last_attempt errors, this field is final and errors are never removed from here, as the ResizeRequest is not going to retry.",
     ).optional(),
     lastAttempt: z.object({
       error: z.object({
@@ -287,7 +288,7 @@ const InputsSchema = z.object({
     }).optional(),
   }).optional(),
   zone: z.string().describe(
-    "Output only. [Output Only] The URL of azone where the resize request is located. Populated only for zonal resize requests.",
+    "Output only. The URL of a zone where the resize request is located. Populated only for zonal resize requests.",
   ).optional(),
   instanceGroupManager: z.string().describe(
     "The name of the managed instance group to which the resize request will be added. Name should conform to RFC1035 or be a resource ID.",
@@ -299,7 +300,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/instancegroupmanagerresizerequests",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -343,6 +344,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/instancegroupmanagers.ts
+++ b/model/gcp/compute/extensions/models/instancegroupmanagers.ts
@@ -150,43 +150,43 @@ const GlobalArgsSchema = z.object({
   ).optional(),
   currentActions: z.object({
     abandoning: z.number().int().describe(
-      "Output only. [Output Only] The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
+      "Output only. The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
     ).optional(),
     creating: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
     ).optional(),
     creatingWithoutRetries: z.number().int().describe(
-      "Output only. [Output Only] The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
+      "Output only. The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
     ).optional(),
     deleting: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
     ).optional(),
     none: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are running and have no scheduled actions.",
+      "Output only. The number of instances in the managed instance group that are running and have no scheduled actions.",
     ).optional(),
     recreating: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
     ).optional(),
     refreshing: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
+      "Output only. The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
     ).optional(),
     restarting: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
     ).optional(),
     resuming: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
     ).optional(),
     starting: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
     ).optional(),
     stopping: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
     ).optional(),
     suspending: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
     ).optional(),
     verifying: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
+      "Output only. The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
     ).optional(),
   }).optional(),
   description: z.string().describe("An optional description of this resource.")
@@ -297,15 +297,15 @@ const GlobalArgsSchema = z.object({
   status: z.object({
     allInstancesConfig: z.object({
       currentRevision: z.string().describe(
-        "Output only. [Output Only] Current all-instances configuration revision. This value is in RFC3339 text format.",
+        "Output only. Current all-instances configuration revision. This value is in RFC3339 text format.",
       ).optional(),
       effective: z.boolean().describe(
-        "Output only. [Output Only] A bit indicating whether this configuration has been applied to all managed instances in the group.",
+        "Output only. A bit indicating whether this configuration has been applied to all managed instances in the group.",
       ).optional(),
     }).optional(),
     appliedAcceleratorTopologies: z.array(z.object({
       acceleratorTopology: z.string().describe(
-        'Output only. [Output Only] Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
+        'Output only. Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
       ).optional(),
       state: z.enum([
         "ACTIVATING",
@@ -314,29 +314,27 @@ const GlobalArgsSchema = z.object({
         "FAILED",
         "INCOMPLETE",
         "REACTIVATING",
-      ]).describe(
-        "Output only. [Output Only] The state of the accelerator topology.",
-      ).optional(),
+      ]).describe("Output only. The state of the accelerator topology.")
+        .optional(),
       stateDetails: z.object({
         error: z.object({
           errors: z.unknown().describe(
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
-        }).describe("Output only. [Output Only] Encountered errors.")
-          .optional(),
+        }).describe("Output only. Encountered errors.").optional(),
         timestamp: z.string().describe(
-          "Output only. [Output Only] Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
+          "Output only. Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
         ).optional(),
       }).optional(),
     })).describe(
-      "Output only. [Output Only] The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
+      "Output only. The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
     ).optional(),
     autoscaler: z.string().describe(
-      "Output only. [Output Only] The URL of theAutoscaler that targets this instance group manager.",
+      "Output only. The URL of theAutoscaler that targets this instance group manager.",
     ).optional(),
     bulkInstanceOperation: z.object({
       inProgress: z.boolean().describe(
-        "Output only. [Output Only] Informs whether bulk instance operation is in progress.",
+        "Output only. Informs whether bulk instance operation is in progress.",
       ).optional(),
       lastProgressCheck: z.object({
         error: z.object({
@@ -344,21 +342,64 @@ const GlobalArgsSchema = z.object({
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
         }).describe(
-          "Output only. [Output Only] Errors encountered during bulk instance operation.",
+          "Output only. Errors encountered during bulk instance operation.",
         ).optional(),
         timestamp: z.string().describe(
-          "Output only. [Output Only] Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
+          "Output only. Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
         ).optional(),
       }).optional(),
     }).describe(
       "Bulk instance operation is the creation of VMs in a MIG when the targetSizePolicy.mode is set to BULK.",
     ).optional(),
+    currentInstanceStatuses: z.object({
+      deprovisioning: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have DEPROVISIONING status.",
+      ).optional(),
+      nonExistent: z.number().int().describe(
+        "Output only. The number of instances that have not been created yet or have been deleted. Includes only instances that would be shown in the listManagedInstances method and not all instances that have been deleted in the lifetime of the MIG. Does not include FlexStart instances that are waiting for the resources availability, they are considered as 'pending'.",
+      ).optional(),
+      pending: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have PENDING status, that is FlexStart instances that are waiting for resources. Instances that do not exist because of the other reasons are counted as 'non_existent'.",
+      ).optional(),
+      pendingStop: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have PENDING_STOP status.",
+      ).optional(),
+      provisioning: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have PROVISIONING status.",
+      ).optional(),
+      repairing: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have REPAIRING status.",
+      ).optional(),
+      running: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have RUNNING status.",
+      ).optional(),
+      staging: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have STAGING status.",
+      ).optional(),
+      stopped: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have STOPPED status.",
+      ).optional(),
+      stopping: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have STOPPING status.",
+      ).optional(),
+      suspended: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have SUSPENDED status.",
+      ).optional(),
+      suspending: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have SUSPENDING status.",
+      ).optional(),
+      terminated: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have TERMINATED status.",
+      ).optional(),
+    }).describe(
+      "The list of instance statuses and the number of instances in this managed instance group that have the status. For more information about how to interpret each status check the instance lifecycle documentation. Currently only shown for TPU MIGs.",
+    ).optional(),
     isStable: z.boolean().describe(
-      "Output only. [Output Only] A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
+      "Output only. A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
     ).optional(),
     stateful: z.object({
       hasStatefulConfig: z.boolean().describe(
-        "Output only. [Output Only] A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
+        "Output only. A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
       ).optional(),
       perInstanceConfigs: z.object({
         allEffective: z.boolean().describe(
@@ -368,7 +409,7 @@ const GlobalArgsSchema = z.object({
     }).optional(),
     versionTarget: z.object({
       isReached: z.boolean().describe(
-        "Output only. [Output Only] A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
+        "Output only. A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
       ).optional(),
     }).optional(),
   }).optional(),
@@ -461,7 +502,7 @@ const GlobalArgsSchema = z.object({
     "Specifies the instance templates used by this managed instance group to create instances. Each version is defined by an instanceTemplate and aname. Every version can appear at most once per instance group. This field overrides the top-level instanceTemplate field. Read more about therelationships between these fields. Exactly one version must leave thetargetSize field unset. That version will be applied to all remaining instances. For more information, read aboutcanary updates.",
   ).optional(),
   zone: z.string().describe(
-    "Output only. [Output Only] The URL of azone where the managed instance group is located (for zonal resources).",
+    "Output only. The URL of azone where the managed instance group is located (for zonal resources).",
   ).optional(),
   requestId: z.string().describe(
     "An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).",
@@ -565,6 +606,21 @@ const StateSchema = z.object({
         timestamp: z.string(),
       }),
     }),
+    currentInstanceStatuses: z.object({
+      deprovisioning: z.number(),
+      nonExistent: z.number(),
+      pending: z.number(),
+      pendingStop: z.number(),
+      provisioning: z.number(),
+      repairing: z.number(),
+      running: z.number(),
+      staging: z.number(),
+      stopped: z.number(),
+      stopping: z.number(),
+      suspended: z.number(),
+      suspending: z.number(),
+      terminated: z.number(),
+    }),
     isStable: z.boolean(),
     stateful: z.object({
       hasStatefulConfig: z.boolean(),
@@ -642,43 +698,43 @@ const InputsSchema = z.object({
   ).optional(),
   currentActions: z.object({
     abandoning: z.number().int().describe(
-      "Output only. [Output Only] The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
+      "Output only. The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
     ).optional(),
     creating: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
     ).optional(),
     creatingWithoutRetries: z.number().int().describe(
-      "Output only. [Output Only] The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
+      "Output only. The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
     ).optional(),
     deleting: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
     ).optional(),
     none: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are running and have no scheduled actions.",
+      "Output only. The number of instances in the managed instance group that are running and have no scheduled actions.",
     ).optional(),
     recreating: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
     ).optional(),
     refreshing: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
+      "Output only. The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
     ).optional(),
     restarting: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
     ).optional(),
     resuming: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
     ).optional(),
     starting: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
     ).optional(),
     stopping: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
     ).optional(),
     suspending: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
     ).optional(),
     verifying: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
+      "Output only. The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
     ).optional(),
   }).optional(),
   description: z.string().describe("An optional description of this resource.")
@@ -789,15 +845,15 @@ const InputsSchema = z.object({
   status: z.object({
     allInstancesConfig: z.object({
       currentRevision: z.string().describe(
-        "Output only. [Output Only] Current all-instances configuration revision. This value is in RFC3339 text format.",
+        "Output only. Current all-instances configuration revision. This value is in RFC3339 text format.",
       ).optional(),
       effective: z.boolean().describe(
-        "Output only. [Output Only] A bit indicating whether this configuration has been applied to all managed instances in the group.",
+        "Output only. A bit indicating whether this configuration has been applied to all managed instances in the group.",
       ).optional(),
     }).optional(),
     appliedAcceleratorTopologies: z.array(z.object({
       acceleratorTopology: z.string().describe(
-        'Output only. [Output Only] Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
+        'Output only. Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
       ).optional(),
       state: z.enum([
         "ACTIVATING",
@@ -806,29 +862,27 @@ const InputsSchema = z.object({
         "FAILED",
         "INCOMPLETE",
         "REACTIVATING",
-      ]).describe(
-        "Output only. [Output Only] The state of the accelerator topology.",
-      ).optional(),
+      ]).describe("Output only. The state of the accelerator topology.")
+        .optional(),
       stateDetails: z.object({
         error: z.object({
           errors: z.unknown().describe(
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
-        }).describe("Output only. [Output Only] Encountered errors.")
-          .optional(),
+        }).describe("Output only. Encountered errors.").optional(),
         timestamp: z.string().describe(
-          "Output only. [Output Only] Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
+          "Output only. Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
         ).optional(),
       }).optional(),
     })).describe(
-      "Output only. [Output Only] The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
+      "Output only. The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
     ).optional(),
     autoscaler: z.string().describe(
-      "Output only. [Output Only] The URL of theAutoscaler that targets this instance group manager.",
+      "Output only. The URL of theAutoscaler that targets this instance group manager.",
     ).optional(),
     bulkInstanceOperation: z.object({
       inProgress: z.boolean().describe(
-        "Output only. [Output Only] Informs whether bulk instance operation is in progress.",
+        "Output only. Informs whether bulk instance operation is in progress.",
       ).optional(),
       lastProgressCheck: z.object({
         error: z.object({
@@ -836,21 +890,64 @@ const InputsSchema = z.object({
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
         }).describe(
-          "Output only. [Output Only] Errors encountered during bulk instance operation.",
+          "Output only. Errors encountered during bulk instance operation.",
         ).optional(),
         timestamp: z.string().describe(
-          "Output only. [Output Only] Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
+          "Output only. Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
         ).optional(),
       }).optional(),
     }).describe(
       "Bulk instance operation is the creation of VMs in a MIG when the targetSizePolicy.mode is set to BULK.",
     ).optional(),
+    currentInstanceStatuses: z.object({
+      deprovisioning: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have DEPROVISIONING status.",
+      ).optional(),
+      nonExistent: z.number().int().describe(
+        "Output only. The number of instances that have not been created yet or have been deleted. Includes only instances that would be shown in the listManagedInstances method and not all instances that have been deleted in the lifetime of the MIG. Does not include FlexStart instances that are waiting for the resources availability, they are considered as 'pending'.",
+      ).optional(),
+      pending: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have PENDING status, that is FlexStart instances that are waiting for resources. Instances that do not exist because of the other reasons are counted as 'non_existent'.",
+      ).optional(),
+      pendingStop: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have PENDING_STOP status.",
+      ).optional(),
+      provisioning: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have PROVISIONING status.",
+      ).optional(),
+      repairing: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have REPAIRING status.",
+      ).optional(),
+      running: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have RUNNING status.",
+      ).optional(),
+      staging: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have STAGING status.",
+      ).optional(),
+      stopped: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have STOPPED status.",
+      ).optional(),
+      stopping: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have STOPPING status.",
+      ).optional(),
+      suspended: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have SUSPENDED status.",
+      ).optional(),
+      suspending: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have SUSPENDING status.",
+      ).optional(),
+      terminated: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have TERMINATED status.",
+      ).optional(),
+    }).describe(
+      "The list of instance statuses and the number of instances in this managed instance group that have the status. For more information about how to interpret each status check the instance lifecycle documentation. Currently only shown for TPU MIGs.",
+    ).optional(),
     isStable: z.boolean().describe(
-      "Output only. [Output Only] A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
+      "Output only. A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
     ).optional(),
     stateful: z.object({
       hasStatefulConfig: z.boolean().describe(
-        "Output only. [Output Only] A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
+        "Output only. A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
       ).optional(),
       perInstanceConfigs: z.object({
         allEffective: z.boolean().describe(
@@ -860,7 +957,7 @@ const InputsSchema = z.object({
     }).optional(),
     versionTarget: z.object({
       isReached: z.boolean().describe(
-        "Output only. [Output Only] A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
+        "Output only. A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
       ).optional(),
     }).optional(),
   }).optional(),
@@ -953,7 +1050,7 @@ const InputsSchema = z.object({
     "Specifies the instance templates used by this managed instance group to create instances. Each version is defined by an instanceTemplate and aname. Every version can appear at most once per instance group. This field overrides the top-level instanceTemplate field. Read more about therelationships between these fields. Exactly one version must leave thetargetSize field unset. That version will be applied to all remaining instances. For more information, read aboutcanary updates.",
   ).optional(),
   zone: z.string().describe(
-    "Output only. [Output Only] The URL of azone where the managed instance group is located (for zonal resources).",
+    "Output only. The URL of azone where the managed instance group is located (for zonal resources).",
   ).optional(),
   requestId: z.string().describe(
     "An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed. For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments. The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).",
@@ -962,7 +1059,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/instancegroupmanagers",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1006,6 +1103,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/instances.ts
+++ b/model/gcp/compute/extensions/models/instances.ts
@@ -236,7 +236,7 @@ const GlobalArgsSchema = z.object({
         "VIRTIO_SCSI_MULTIQUEUE",
         "WINDOWS",
       ]).describe(
-        "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+        "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
       ).optional(),
     })).describe(
       "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -610,6 +610,9 @@ const GlobalArgsSchema = z.object({
     ).optional(),
     queueCount: z.number().int().describe(
       "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
+    ).optional(),
+    serviceClassId: z.string().describe(
+      "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
     ).optional(),
     stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
       "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
@@ -989,6 +992,7 @@ const StateSchema = z.object({
     nicType: z.string(),
     parentNicName: z.string(),
     queueCount: z.number(),
+    serviceClassId: z.string(),
     stackType: z.string(),
     subnetwork: z.string(),
     vlan: z.number(),
@@ -1216,7 +1220,7 @@ const InputsSchema = z.object({
         "VIRTIO_SCSI_MULTIQUEUE",
         "WINDOWS",
       ]).describe(
-        "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+        "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
       ).optional(),
     })).describe(
       "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -1591,6 +1595,9 @@ const InputsSchema = z.object({
     queueCount: z.number().int().describe(
       "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
     ).optional(),
+    serviceClassId: z.string().describe(
+      "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
+    ).optional(),
     stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
       "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
     ).optional(),
@@ -1798,7 +1805,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/instances",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1845,6 +1852,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -2341,6 +2353,7 @@ export const model = {
         nicType: z.any().optional(),
         parentNicName: z.any().optional(),
         queueCount: z.any().optional(),
+        serviceClassId: z.any().optional(),
         stackType: z.any().optional(),
         subnetwork: z.any().optional(),
         vlan: z.any().optional(),
@@ -2407,6 +2420,9 @@ export const model = {
         }
         if (args["queueCount"] !== undefined) {
           body["queueCount"] = args["queueCount"];
+        }
+        if (args["serviceClassId"] !== undefined) {
+          body["serviceClassId"] = args["serviceClassId"];
         }
         if (args["stackType"] !== undefined) {
           body["stackType"] = args["stackType"];
@@ -4269,6 +4285,7 @@ export const model = {
         nicType: z.any().optional(),
         parentNicName: z.any().optional(),
         queueCount: z.any().optional(),
+        serviceClassId: z.any().optional(),
         stackType: z.any().optional(),
         subnetwork: z.any().optional(),
         vlan: z.any().optional(),
@@ -4337,6 +4354,9 @@ export const model = {
         }
         if (args["queueCount"] !== undefined) {
           body["queueCount"] = args["queueCount"];
+        }
+        if (args["serviceClassId"] !== undefined) {
+          body["serviceClassId"] = args["serviceClassId"];
         }
         if (args["stackType"] !== undefined) {
           body["stackType"] = args["stackType"];

--- a/model/gcp/compute/extensions/models/instancetemplates.ts
+++ b/model/gcp/compute/extensions/models/instancetemplates.ts
@@ -166,7 +166,7 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -480,6 +480,9 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
+      ).optional(),
+      serviceClassId: z.string().describe(
+        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
       ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
@@ -826,6 +829,7 @@ const StateSchema = z.object({
       nicType: z.string(),
       parentNicName: z.string(),
       queueCount: z.number(),
+      serviceClassId: z.string(),
       stackType: z.string(),
       subnetwork: z.string(),
       vlan: z.number(),
@@ -994,7 +998,7 @@ const InputsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -1309,6 +1313,9 @@ const InputsSchema = z.object({
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
       ).optional(),
+      serviceClassId: z.string().describe(
+        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
+      ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
       ).optional(),
@@ -1508,7 +1515,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/instancetemplates",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1552,6 +1559,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/instantsnapshots.ts
+++ b/model/gcp/compute/extensions/models/instantsnapshots.ts
@@ -148,6 +148,8 @@ const StateSchema = z.object({
   selfLinkWithId: z.string().optional(),
   sourceDisk: z.string().optional(),
   sourceDiskId: z.string().optional(),
+  sourceInstantSnapshotGroup: z.string().optional(),
+  sourceInstantSnapshotGroupId: z.string().optional(),
   status: z.string().optional(),
   zone: z.string().optional(),
 }).passthrough();
@@ -191,7 +193,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/instantsnapshots",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -225,6 +227,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/machineimages.ts
+++ b/model/gcp/compute/extensions/models/machineimages.ts
@@ -168,7 +168,7 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -483,6 +483,9 @@ const GlobalArgsSchema = z.object({
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
       ).optional(),
+      serviceClassId: z.string().describe(
+        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
+      ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
       ).optional(),
@@ -747,7 +750,7 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -953,6 +956,9 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
+      ).optional(),
+      serviceClassId: z.string().describe(
+        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
       ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
@@ -1228,6 +1234,7 @@ const StateSchema = z.object({
       nicType: z.string(),
       parentNicName: z.string(),
       queueCount: z.number(),
+      serviceClassId: z.string(),
       stackType: z.string(),
       subnetwork: z.string(),
       vlan: z.number(),
@@ -1414,6 +1421,7 @@ const StateSchema = z.object({
       nicType: z.string(),
       parentNicName: z.string(),
       queueCount: z.number(),
+      serviceClassId: z.string(),
       stackType: z.string(),
       subnetwork: z.string(),
       vlan: z.number(),
@@ -1554,7 +1562,7 @@ const InputsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -1869,6 +1877,9 @@ const InputsSchema = z.object({
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
       ).optional(),
+      serviceClassId: z.string().describe(
+        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
+      ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
       ).optional(),
@@ -2133,7 +2144,7 @@ const InputsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -2340,6 +2351,9 @@ const InputsSchema = z.object({
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
       ).optional(),
+      serviceClassId: z.string().describe(
+        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
+      ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
       ).optional(),
@@ -2469,7 +2483,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/machineimages",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -2513,6 +2527,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/networkattachments.ts
+++ b/model/gcp/compute/extensions/models/networkattachments.ts
@@ -158,6 +158,7 @@ const StateSchema = z.object({
     ipv6Address: z.string(),
     projectIdOrNum: z.string(),
     secondaryIpCidrRanges: z.array(z.string()),
+    serviceClassId: z.string(),
     status: z.string(),
     subnetwork: z.string(),
     subnetworkCidrRange: z.string(),
@@ -212,7 +213,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/networkattachments",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -256,6 +257,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/regionbackendservices.ts
+++ b/model/gcp/compute/extensions/models/regionbackendservices.ts
@@ -130,6 +130,7 @@ const GlobalArgsSchema = z.object({
     balancingMode: z.enum([
       "CONNECTION",
       "CUSTOM_METRICS",
+      "IN_FLIGHT",
       "RATE",
       "UTILIZATION",
     ]).describe(
@@ -169,6 +170,15 @@ const GlobalArgsSchema = z.object({
     maxConnectionsPerInstance: z.number().int().describe(
       "Defines a target maximum number of simultaneous connections. For usage guidelines, seeConnection balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isRATE.",
     ).optional(),
+    maxInFlightRequests: z.number().int().describe(
+      "Defines a maximum number of in-flight requests for the whole NEG or instance group. Not available if backend's balancingMode isRATE or CONNECTION.",
+    ).optional(),
+    maxInFlightRequestsPerEndpoint: z.number().int().describe(
+      "Defines a maximum number of in-flight requests for a single endpoint. Not available if backend's balancingMode is RATE or CONNECTION.",
+    ).optional(),
+    maxInFlightRequestsPerInstance: z.number().int().describe(
+      "Defines a maximum number of in-flight requests for a single VM. Not available if backend's balancingMode is RATE or CONNECTION.",
+    ).optional(),
     maxRate: z.number().int().describe(
       "Defines a maximum number of HTTP requests per second (RPS). For usage guidelines, seeRate balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isCONNECTION.",
     ).optional(),
@@ -192,6 +202,8 @@ const GlobalArgsSchema = z.object({
       .describe(
         "This field indicates whether this backend should be fully utilized before sending traffic to backends with default preference. The possible values are: - PREFERRED: Backends with this preference level will be filled up to their capacity limits first, based on RTT. - DEFAULT: If preferred backends don't have enough capacity, backends in this layer would be used and traffic would be assigned based on the load balancing algorithm you use. This is the default",
       ).optional(),
+    trafficDuration: z.enum(["LONG", "SHORT", "TRAFFIC_DURATION_UNSPECIFIED"])
+      .optional(),
   })).describe("The list of backends that serve this BackendService.")
     .optional(),
   cdnPolicy: z.object({
@@ -490,7 +502,7 @@ const GlobalArgsSchema = z.object({
     "WEIGHTED_MAGLEV",
     "WEIGHTED_ROUND_ROBIN",
   ]).describe(
-    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
+    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
   ).optional(),
   logConfig: z.object({
     enable: z.boolean().describe(
@@ -733,6 +745,9 @@ const StateSchema = z.object({
     maxConnections: z.number(),
     maxConnectionsPerEndpoint: z.number(),
     maxConnectionsPerInstance: z.number(),
+    maxInFlightRequests: z.number(),
+    maxInFlightRequestsPerEndpoint: z.number(),
+    maxInFlightRequestsPerInstance: z.number(),
     maxRate: z.number(),
     maxRatePerEndpoint: z.number(),
     maxRatePerInstance: z.number(),
@@ -741,6 +756,7 @@ const StateSchema = z.object({
       resourceUri: z.string(),
     }),
     preference: z.string(),
+    trafficDuration: z.string(),
   })).optional(),
   cdnPolicy: z.object({
     bypassCacheOnRequestHeaders: z.array(z.object({
@@ -944,6 +960,7 @@ const InputsSchema = z.object({
     balancingMode: z.enum([
       "CONNECTION",
       "CUSTOM_METRICS",
+      "IN_FLIGHT",
       "RATE",
       "UTILIZATION",
     ]).describe(
@@ -983,6 +1000,15 @@ const InputsSchema = z.object({
     maxConnectionsPerInstance: z.number().int().describe(
       "Defines a target maximum number of simultaneous connections. For usage guidelines, seeConnection balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isRATE.",
     ).optional(),
+    maxInFlightRequests: z.number().int().describe(
+      "Defines a maximum number of in-flight requests for the whole NEG or instance group. Not available if backend's balancingMode isRATE or CONNECTION.",
+    ).optional(),
+    maxInFlightRequestsPerEndpoint: z.number().int().describe(
+      "Defines a maximum number of in-flight requests for a single endpoint. Not available if backend's balancingMode is RATE or CONNECTION.",
+    ).optional(),
+    maxInFlightRequestsPerInstance: z.number().int().describe(
+      "Defines a maximum number of in-flight requests for a single VM. Not available if backend's balancingMode is RATE or CONNECTION.",
+    ).optional(),
     maxRate: z.number().int().describe(
       "Defines a maximum number of HTTP requests per second (RPS). For usage guidelines, seeRate balancing mode and Utilization balancing mode. Not available if the backend's balancingMode isCONNECTION.",
     ).optional(),
@@ -1006,6 +1032,8 @@ const InputsSchema = z.object({
       .describe(
         "This field indicates whether this backend should be fully utilized before sending traffic to backends with default preference. The possible values are: - PREFERRED: Backends with this preference level will be filled up to their capacity limits first, based on RTT. - DEFAULT: If preferred backends don't have enough capacity, backends in this layer would be used and traffic would be assigned based on the load balancing algorithm you use. This is the default",
       ).optional(),
+    trafficDuration: z.enum(["LONG", "SHORT", "TRAFFIC_DURATION_UNSPECIFIED"])
+      .optional(),
   })).describe("The list of backends that serve this BackendService.")
     .optional(),
   cdnPolicy: z.object({
@@ -1304,7 +1332,7 @@ const InputsSchema = z.object({
     "WEIGHTED_MAGLEV",
     "WEIGHTED_ROUND_ROBIN",
   ]).describe(
-    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
+    "The load balancing algorithm used within the scope of the locality. The possible values are: - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default. - LEAST_REQUEST: An O(1) algorithm which selects two random healthy hosts and picks the host which has fewer active requests. - RING_HASH: The ring/modulo hash load balancer implements consistent hashing to backends. The algorithm has the property that the addition/removal of a host from a set of N hosts only affects 1/N of the requests. - RANDOM: The load balancer selects a random healthy host. - ORIGINAL_DESTINATION: Backend host is selected based on the client connection metadata, i.e., connections are opened to the same address as the destination address of the incoming connection before the connection was redirected to the load balancer. - MAGLEV: used as a drop in replacement for the ring hash load balancer. Maglev is not as stable as ring hash but has faster table lookup build times and host selection times. For more information about Maglev, see Maglev: A Fast and Reliable Software Network Load Balancer. - WEIGHTED_ROUND_ROBIN: Per-endpoint Weighted Round Robin Load Balancing using weights computed from Backend reported Custom Metrics. If set, the Backend Service responses are expected to contain non-standard HTTP response header field Endpoint-Load-Metrics. The reported metrics to use for computing the weights are specified via thecustomMetrics field. This field is applicable to either: - A regional backend service with the service protocol set to HTTP, HTTPS, HTTP2 or H2C, and load_balancing_scheme set to INTERNAL_MANAGED. - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED, INTERNAL_MANAGED, or EXTERNAL_MANAGED. If sessionAffinity is not configured—that is, if session affinity remains at the default value of NONE—then the default value for localityLbPolicy is ROUND_ROBIN. If session affinity is set to a value other than NONE, then the default value for localityLbPolicy isMAGLEV. Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true. localityLbPolicy cannot be specified with haPolicy.",
   ).optional(),
   logConfig: z.object({
     enable: z.boolean().describe(
@@ -1533,7 +1561,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regionbackendservices",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1577,6 +1605,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/regioncommitments.ts
+++ b/model/gcp/compute/extensions/models/regioncommitments.ts
@@ -124,6 +124,11 @@ const GlobalArgsSchema = z.object({
     .describe(
       "Name of the commitment. You must specify a name when you purchase the commitment. The name must be 1-63 characters long, and comply withRFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.",
     ).optional(),
+  params: z.object({
+    resourceManagerTags: z.record(z.string(), z.string()).describe(
+      "Input only. Resource manager tags to be bound to the commitment. Tag keys and values have the same definition as resource manager tags. Keys and values can be either in numeric format, such as `tagKeys/{tag_key_id}` and `tagValues/{tag_value_id}` or in namespaced format such as `{org_id|project_id}/{tag_key_short_name}` and `{tag_value_short_name}`. The field is ignored (both PUT & PATCH) when empty.",
+    ).optional(),
+  }).describe("Additional commitment params.").optional(),
   plan: z.enum(["INVALID", "THIRTY_SIX_MONTH", "TWELVE_MONTH"]).describe(
     "The minimum time duration that you commit to purchasing resources. The plan that you choose determines the preset term length of the commitment (which is 1 year or 3 years) and affects the discount rate that you receive for your resources. Committing to a longer time duration typically gives you a higher discount rate. The supported values for this field are TWELVE_MONTH (1 year), andTHIRTY_SIX_MONTH (3 years).",
   ).optional(),
@@ -173,6 +178,10 @@ const GlobalArgsSchema = z.object({
     commitment: z.string().describe(
       "Output only. [Output Only] Full or partial URL to a parent commitment. This field displays for reservations that are tied to a commitment.",
     ).optional(),
+    confidentialComputeType: z.enum([
+      "CONFIDENTIAL_COMPUTE_TYPE_TDX",
+      "CONFIDENTIAL_COMPUTE_TYPE_UNSPECIFIED",
+    ]).optional(),
     creationTimestamp: z.string().describe(
       "Output only. [Output Only] Creation timestamp inRFC3339 text format.",
     ).optional(),
@@ -472,6 +481,9 @@ const StateSchema = z.object({
   }).optional(),
   mergeSourceCommitments: z.array(z.string()).optional(),
   name: z.string(),
+  params: z.object({
+    resourceManagerTags: z.record(z.string(), z.unknown()),
+  }).optional(),
   plan: z.string().optional(),
   region: z.string().optional(),
   reservations: z.array(z.object({
@@ -489,6 +501,7 @@ const StateSchema = z.object({
       workloadType: z.string(),
     }),
     commitment: z.string(),
+    confidentialComputeType: z.string(),
     creationTimestamp: z.string(),
     deleteAfterDuration: z.object({
       nanos: z.number(),
@@ -612,6 +625,11 @@ const InputsSchema = z.object({
     .describe(
       "Name of the commitment. You must specify a name when you purchase the commitment. The name must be 1-63 characters long, and comply withRFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.",
     ).optional(),
+  params: z.object({
+    resourceManagerTags: z.record(z.string(), z.string()).describe(
+      "Input only. Resource manager tags to be bound to the commitment. Tag keys and values have the same definition as resource manager tags. Keys and values can be either in numeric format, such as `tagKeys/{tag_key_id}` and `tagValues/{tag_value_id}` or in namespaced format such as `{org_id|project_id}/{tag_key_short_name}` and `{tag_value_short_name}`. The field is ignored (both PUT & PATCH) when empty.",
+    ).optional(),
+  }).describe("Additional commitment params.").optional(),
   plan: z.enum(["INVALID", "THIRTY_SIX_MONTH", "TWELVE_MONTH"]).describe(
     "The minimum time duration that you commit to purchasing resources. The plan that you choose determines the preset term length of the commitment (which is 1 year or 3 years) and affects the discount rate that you receive for your resources. Committing to a longer time duration typically gives you a higher discount rate. The supported values for this field are TWELVE_MONTH (1 year), andTHIRTY_SIX_MONTH (3 years).",
   ).optional(),
@@ -661,6 +679,10 @@ const InputsSchema = z.object({
     commitment: z.string().describe(
       "Output only. [Output Only] Full or partial URL to a parent commitment. This field displays for reservations that are tied to a commitment.",
     ).optional(),
+    confidentialComputeType: z.enum([
+      "CONFIDENTIAL_COMPUTE_TYPE_TDX",
+      "CONFIDENTIAL_COMPUTE_TYPE_UNSPECIFIED",
+    ]).optional(),
     creationTimestamp: z.string().describe(
       "Output only. [Output Only] Creation timestamp inRFC3339 text format.",
     ).optional(),
@@ -945,7 +967,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regioncommitments",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -998,6 +1020,11 @@ export const model = {
         return rest;
       },
     },
+    {
+      toVersion: "2026.04.07.1",
+      description: "Added: params",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
@@ -1042,6 +1069,7 @@ export const model = {
           body["mergeSourceCommitments"] = g["mergeSourceCommitments"];
         }
         if (g["name"] !== undefined) body["name"] = g["name"];
+        if (g["params"] !== undefined) body["params"] = g["params"];
         if (g["plan"] !== undefined) body["plan"] = g["plan"];
         if (g["reservations"] !== undefined) {
           body["reservations"] = g["reservations"];
@@ -1154,6 +1182,7 @@ export const model = {
           body["mergeSourceCommitments"] = g["mergeSourceCommitments"];
         }
         if (g["name"] !== undefined) body["name"] = g["name"];
+        if (g["params"] !== undefined) body["params"] = g["params"];
         if (g["plan"] !== undefined) body["plan"] = g["plan"];
         if (g["reservations"] !== undefined) {
           body["reservations"] = g["reservations"];

--- a/model/gcp/compute/extensions/models/regioncompositehealthchecks.ts
+++ b/model/gcp/compute/extensions/models/regioncompositehealthchecks.ts
@@ -190,7 +190,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regioncompositehealthchecks",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -234,6 +234,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -470,6 +475,48 @@ export const model = {
           }
           throw error;
         }
+      },
+    },
+    get_health: {
+      description: "get health",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, unknown>, context: any) => {
+        const g = context.globalArgs;
+        const projectId = await getProjectId();
+        const params: Record<string, string> = { project: projectId };
+        if (g["region"] !== undefined) params["region"] = String(g["region"]);
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          (g.name?.toString() ?? "current").replace(/[\/\\]/g, "_").replace(
+            /\.\./g,
+            "_",
+          ).replace(/\0/g, ""),
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        params["compositeHealthCheck"] = existing["name"]?.toString() ??
+          g["name"]?.toString() ?? "";
+        const result = await createResource(
+          BASE_URL,
+          {
+            "id": "compute.regionCompositeHealthChecks.getHealth",
+            "path":
+              "projects/{project}/regions/{region}/compositeHealthChecks/{compositeHealthCheck}/getHealth",
+            "httpMethod": "GET",
+            "parameterOrder": ["project", "region", "compositeHealthCheck"],
+            "parameters": {
+              "compositeHealthCheck": { "location": "path", "required": true },
+              "project": { "location": "path", "required": true },
+              "region": { "location": "path", "required": true },
+            },
+          },
+          params,
+          {},
+        );
+        return { result };
       },
     },
   },

--- a/model/gcp/compute/extensions/models/regiondisks.ts
+++ b/model/gcp/compute/extensions/models/regiondisks.ts
@@ -191,7 +191,7 @@ const GlobalArgsSchema = z.object({
       "VIRTIO_SCSI_MULTIQUEUE",
       "WINDOWS",
     ]).describe(
-      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
     ).optional(),
   })).describe(
     "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -477,7 +477,7 @@ const InputsSchema = z.object({
       "VIRTIO_SCSI_MULTIQUEUE",
       "WINDOWS",
     ]).describe(
-      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+      "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
     ).optional(),
   })).describe(
     "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -615,7 +615,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regiondisks",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -659,6 +659,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -1091,6 +1096,8 @@ export const model = {
     bulk_insert: {
       description: "bulk insert",
       arguments: z.object({
+        instantSnapshotGroupParameters: z.any().optional(),
+        snapshotGroupParameters: z.any().optional(),
         sourceConsistencyGroupPolicy: z.any().optional(),
       }),
       execute: async (args: Record<string, unknown>, context: any) => {
@@ -1099,6 +1106,13 @@ export const model = {
         const params: Record<string, string> = { project: projectId };
         if (g["region"] !== undefined) params["region"] = String(g["region"]);
         const body: Record<string, unknown> = {};
+        if (args["instantSnapshotGroupParameters"] !== undefined) {
+          body["instantSnapshotGroupParameters"] =
+            args["instantSnapshotGroupParameters"];
+        }
+        if (args["snapshotGroupParameters"] !== undefined) {
+          body["snapshotGroupParameters"] = args["snapshotGroupParameters"];
+        }
         if (args["sourceConsistencyGroupPolicy"] !== undefined) {
           body["sourceConsistencyGroupPolicy"] =
             args["sourceConsistencyGroupPolicy"];
@@ -1145,10 +1159,13 @@ export const model = {
         locationHint: z.any().optional(),
         name: z.any().optional(),
         params: z.any().optional(),
+        region: z.any().optional(),
         satisfiesPzi: z.any().optional(),
         satisfiesPzs: z.any().optional(),
         selfLink: z.any().optional(),
         snapshotEncryptionKey: z.any().optional(),
+        snapshotGroupId: z.any().optional(),
+        snapshotGroupName: z.any().optional(),
         snapshotType: z.any().optional(),
         sourceDisk: z.any().optional(),
         sourceDiskEncryptionKey: z.any().optional(),
@@ -1232,6 +1249,7 @@ export const model = {
         }
         if (args["name"] !== undefined) body["name"] = args["name"];
         if (args["params"] !== undefined) body["params"] = args["params"];
+        if (args["region"] !== undefined) body["region"] = args["region"];
         if (args["satisfiesPzi"] !== undefined) {
           body["satisfiesPzi"] = args["satisfiesPzi"];
         }
@@ -1241,6 +1259,12 @@ export const model = {
         if (args["selfLink"] !== undefined) body["selfLink"] = args["selfLink"];
         if (args["snapshotEncryptionKey"] !== undefined) {
           body["snapshotEncryptionKey"] = args["snapshotEncryptionKey"];
+        }
+        if (args["snapshotGroupId"] !== undefined) {
+          body["snapshotGroupId"] = args["snapshotGroupId"];
+        }
+        if (args["snapshotGroupName"] !== undefined) {
+          body["snapshotGroupName"] = args["snapshotGroupName"];
         }
         if (args["snapshotType"] !== undefined) {
           body["snapshotType"] = args["snapshotType"];
@@ -1519,6 +1543,55 @@ export const model = {
             "httpMethod": "POST",
             "parameterOrder": ["project", "region"],
             "parameters": {
+              "project": { "location": "path", "required": true },
+              "region": { "location": "path", "required": true },
+              "requestId": { "location": "query" },
+            },
+          },
+          params,
+          body,
+        );
+        return { result };
+      },
+    },
+    update_kms_key: {
+      description: "update kms key",
+      arguments: z.object({
+        kmsKeyName: z.any().optional(),
+      }),
+      execute: async (args: Record<string, unknown>, context: any) => {
+        const g = context.globalArgs;
+        const projectId = await getProjectId();
+        const params: Record<string, string> = { project: projectId };
+        if (g["region"] !== undefined) params["region"] = String(g["region"]);
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          (g.name?.toString() ?? "current").replace(/[\/\\]/g, "_").replace(
+            /\.\./g,
+            "_",
+          ).replace(/\0/g, ""),
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        params["disk"] = existing["name"]?.toString() ??
+          g["name"]?.toString() ?? "";
+        const body: Record<string, unknown> = {};
+        if (args["kmsKeyName"] !== undefined) {
+          body["kmsKeyName"] = args["kmsKeyName"];
+        }
+        const result = await createResource(
+          BASE_URL,
+          {
+            "id": "compute.regionDisks.updateKmsKey",
+            "path":
+              "projects/{project}/regions/{region}/disks/{disk}/updateKmsKey",
+            "httpMethod": "POST",
+            "parameterOrder": ["project", "region", "disk"],
+            "parameters": {
+              "disk": { "location": "path", "required": true },
               "project": { "location": "path", "required": true },
               "region": { "location": "path", "required": true },
               "requestId": { "location": "query" },

--- a/model/gcp/compute/extensions/models/regionhealthsources.ts
+++ b/model/gcp/compute/extensions/models/regionhealthsources.ts
@@ -194,7 +194,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regionhealthsources",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -238,6 +238,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -466,6 +471,48 @@ export const model = {
           }
           throw error;
         }
+      },
+    },
+    get_health: {
+      description: "get health",
+      arguments: z.object({}),
+      execute: async (_args: Record<string, unknown>, context: any) => {
+        const g = context.globalArgs;
+        const projectId = await getProjectId();
+        const params: Record<string, string> = { project: projectId };
+        if (g["region"] !== undefined) params["region"] = String(g["region"]);
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          (g.name?.toString() ?? "current").replace(/[\/\\]/g, "_").replace(
+            /\.\./g,
+            "_",
+          ).replace(/\0/g, ""),
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        params["healthSource"] = existing["name"]?.toString() ??
+          g["name"]?.toString() ?? "";
+        const result = await createResource(
+          BASE_URL,
+          {
+            "id": "compute.regionHealthSources.getHealth",
+            "path":
+              "projects/{project}/regions/{region}/healthSources/{healthSource}/getHealth",
+            "httpMethod": "GET",
+            "parameterOrder": ["project", "region", "healthSource"],
+            "parameters": {
+              "healthSource": { "location": "path", "required": true },
+              "project": { "location": "path", "required": true },
+              "region": { "location": "path", "required": true },
+            },
+          },
+          params,
+          {},
+        );
+        return { result };
       },
     },
   },

--- a/model/gcp/compute/extensions/models/regioninstancegroupmanagers.ts
+++ b/model/gcp/compute/extensions/models/regioninstancegroupmanagers.ts
@@ -150,43 +150,43 @@ const GlobalArgsSchema = z.object({
   ).optional(),
   currentActions: z.object({
     abandoning: z.number().int().describe(
-      "Output only. [Output Only] The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
+      "Output only. The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
     ).optional(),
     creating: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
     ).optional(),
     creatingWithoutRetries: z.number().int().describe(
-      "Output only. [Output Only] The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
+      "Output only. The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
     ).optional(),
     deleting: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
     ).optional(),
     none: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are running and have no scheduled actions.",
+      "Output only. The number of instances in the managed instance group that are running and have no scheduled actions.",
     ).optional(),
     recreating: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
     ).optional(),
     refreshing: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
+      "Output only. The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
     ).optional(),
     restarting: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
     ).optional(),
     resuming: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
     ).optional(),
     starting: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
     ).optional(),
     stopping: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
     ).optional(),
     suspending: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
     ).optional(),
     verifying: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
+      "Output only. The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
     ).optional(),
   }).optional(),
   description: z.string().describe("An optional description of this resource.")
@@ -300,15 +300,15 @@ const GlobalArgsSchema = z.object({
   status: z.object({
     allInstancesConfig: z.object({
       currentRevision: z.string().describe(
-        "Output only. [Output Only] Current all-instances configuration revision. This value is in RFC3339 text format.",
+        "Output only. Current all-instances configuration revision. This value is in RFC3339 text format.",
       ).optional(),
       effective: z.boolean().describe(
-        "Output only. [Output Only] A bit indicating whether this configuration has been applied to all managed instances in the group.",
+        "Output only. A bit indicating whether this configuration has been applied to all managed instances in the group.",
       ).optional(),
     }).optional(),
     appliedAcceleratorTopologies: z.array(z.object({
       acceleratorTopology: z.string().describe(
-        'Output only. [Output Only] Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
+        'Output only. Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
       ).optional(),
       state: z.enum([
         "ACTIVATING",
@@ -317,29 +317,27 @@ const GlobalArgsSchema = z.object({
         "FAILED",
         "INCOMPLETE",
         "REACTIVATING",
-      ]).describe(
-        "Output only. [Output Only] The state of the accelerator topology.",
-      ).optional(),
+      ]).describe("Output only. The state of the accelerator topology.")
+        .optional(),
       stateDetails: z.object({
         error: z.object({
           errors: z.unknown().describe(
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
-        }).describe("Output only. [Output Only] Encountered errors.")
-          .optional(),
+        }).describe("Output only. Encountered errors.").optional(),
         timestamp: z.string().describe(
-          "Output only. [Output Only] Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
+          "Output only. Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
         ).optional(),
       }).optional(),
     })).describe(
-      "Output only. [Output Only] The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
+      "Output only. The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
     ).optional(),
     autoscaler: z.string().describe(
-      "Output only. [Output Only] The URL of theAutoscaler that targets this instance group manager.",
+      "Output only. The URL of theAutoscaler that targets this instance group manager.",
     ).optional(),
     bulkInstanceOperation: z.object({
       inProgress: z.boolean().describe(
-        "Output only. [Output Only] Informs whether bulk instance operation is in progress.",
+        "Output only. Informs whether bulk instance operation is in progress.",
       ).optional(),
       lastProgressCheck: z.object({
         error: z.object({
@@ -347,21 +345,64 @@ const GlobalArgsSchema = z.object({
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
         }).describe(
-          "Output only. [Output Only] Errors encountered during bulk instance operation.",
+          "Output only. Errors encountered during bulk instance operation.",
         ).optional(),
         timestamp: z.string().describe(
-          "Output only. [Output Only] Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
+          "Output only. Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
         ).optional(),
       }).optional(),
     }).describe(
       "Bulk instance operation is the creation of VMs in a MIG when the targetSizePolicy.mode is set to BULK.",
     ).optional(),
+    currentInstanceStatuses: z.object({
+      deprovisioning: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have DEPROVISIONING status.",
+      ).optional(),
+      nonExistent: z.number().int().describe(
+        "Output only. The number of instances that have not been created yet or have been deleted. Includes only instances that would be shown in the listManagedInstances method and not all instances that have been deleted in the lifetime of the MIG. Does not include FlexStart instances that are waiting for the resources availability, they are considered as 'pending'.",
+      ).optional(),
+      pending: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have PENDING status, that is FlexStart instances that are waiting for resources. Instances that do not exist because of the other reasons are counted as 'non_existent'.",
+      ).optional(),
+      pendingStop: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have PENDING_STOP status.",
+      ).optional(),
+      provisioning: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have PROVISIONING status.",
+      ).optional(),
+      repairing: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have REPAIRING status.",
+      ).optional(),
+      running: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have RUNNING status.",
+      ).optional(),
+      staging: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have STAGING status.",
+      ).optional(),
+      stopped: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have STOPPED status.",
+      ).optional(),
+      stopping: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have STOPPING status.",
+      ).optional(),
+      suspended: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have SUSPENDED status.",
+      ).optional(),
+      suspending: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have SUSPENDING status.",
+      ).optional(),
+      terminated: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have TERMINATED status.",
+      ).optional(),
+    }).describe(
+      "The list of instance statuses and the number of instances in this managed instance group that have the status. For more information about how to interpret each status check the instance lifecycle documentation. Currently only shown for TPU MIGs.",
+    ).optional(),
     isStable: z.boolean().describe(
-      "Output only. [Output Only] A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
+      "Output only. A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
     ).optional(),
     stateful: z.object({
       hasStatefulConfig: z.boolean().describe(
-        "Output only. [Output Only] A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
+        "Output only. A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
       ).optional(),
       perInstanceConfigs: z.object({
         allEffective: z.boolean().describe(
@@ -371,7 +412,7 @@ const GlobalArgsSchema = z.object({
     }).optional(),
     versionTarget: z.object({
       isReached: z.boolean().describe(
-        "Output only. [Output Only] A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
+        "Output only. A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
       ).optional(),
     }).optional(),
   }).optional(),
@@ -565,6 +606,21 @@ const StateSchema = z.object({
         timestamp: z.string(),
       }),
     }),
+    currentInstanceStatuses: z.object({
+      deprovisioning: z.number(),
+      nonExistent: z.number(),
+      pending: z.number(),
+      pendingStop: z.number(),
+      provisioning: z.number(),
+      repairing: z.number(),
+      running: z.number(),
+      staging: z.number(),
+      stopped: z.number(),
+      stopping: z.number(),
+      suspended: z.number(),
+      suspending: z.number(),
+      terminated: z.number(),
+    }),
     isStable: z.boolean(),
     stateful: z.object({
       hasStatefulConfig: z.boolean(),
@@ -642,43 +698,43 @@ const InputsSchema = z.object({
   ).optional(),
   currentActions: z.object({
     abandoning: z.number().int().describe(
-      "Output only. [Output Only] The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
+      "Output only. The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.",
     ).optional(),
     creating: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully. If you have disabled creation retries, this field will not be populated; instead, the creatingWithoutRetries field will be populated.",
     ).optional(),
     creatingWithoutRetries: z.number().int().describe(
-      "Output only. [Output Only] The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
+      "Output only. The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.",
     ).optional(),
     deleting: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.",
     ).optional(),
     none: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are running and have no scheduled actions.",
+      "Output only. The number of instances in the managed instance group that are running and have no scheduled actions.",
     ).optional(),
     recreating: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.",
     ).optional(),
     refreshing: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
+      "Output only. The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.",
     ).optional(),
     restarting: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.",
     ).optional(),
     resuming: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be resumed or are currently being resumed.",
     ).optional(),
     starting: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be started or are currently being started.",
     ).optional(),
     stopping: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be stopped or are currently being stopped.",
     ).optional(),
     suspending: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
+      "Output only. The number of instances in the managed instance group that are scheduled to be suspended or are currently being suspended.",
     ).optional(),
     verifying: z.number().int().describe(
-      "Output only. [Output Only] The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
+      "Output only. The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.",
     ).optional(),
   }).optional(),
   description: z.string().describe("An optional description of this resource.")
@@ -792,15 +848,15 @@ const InputsSchema = z.object({
   status: z.object({
     allInstancesConfig: z.object({
       currentRevision: z.string().describe(
-        "Output only. [Output Only] Current all-instances configuration revision. This value is in RFC3339 text format.",
+        "Output only. Current all-instances configuration revision. This value is in RFC3339 text format.",
       ).optional(),
       effective: z.boolean().describe(
-        "Output only. [Output Only] A bit indicating whether this configuration has been applied to all managed instances in the group.",
+        "Output only. A bit indicating whether this configuration has been applied to all managed instances in the group.",
       ).optional(),
     }).optional(),
     appliedAcceleratorTopologies: z.array(z.object({
       acceleratorTopology: z.string().describe(
-        'Output only. [Output Only] Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
+        'Output only. Topology in the format of: "16x16", "4x4x4", etc. The value is the same as configured in the WorkloadPolicy.',
       ).optional(),
       state: z.enum([
         "ACTIVATING",
@@ -809,29 +865,27 @@ const InputsSchema = z.object({
         "FAILED",
         "INCOMPLETE",
         "REACTIVATING",
-      ]).describe(
-        "Output only. [Output Only] The state of the accelerator topology.",
-      ).optional(),
+      ]).describe("Output only. The state of the accelerator topology.")
+        .optional(),
       stateDetails: z.object({
         error: z.object({
           errors: z.unknown().describe(
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
-        }).describe("Output only. [Output Only] Encountered errors.")
-          .optional(),
+        }).describe("Output only. Encountered errors.").optional(),
         timestamp: z.string().describe(
-          "Output only. [Output Only] Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
+          "Output only. Timestamp is shown only if there is an error. The field has // RFC3339 // text format.",
         ).optional(),
       }).optional(),
     })).describe(
-      "Output only. [Output Only] The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
+      "Output only. The accelerator topology applied to this MIG. Currently only one accelerator topology is supported.",
     ).optional(),
     autoscaler: z.string().describe(
-      "Output only. [Output Only] The URL of theAutoscaler that targets this instance group manager.",
+      "Output only. The URL of theAutoscaler that targets this instance group manager.",
     ).optional(),
     bulkInstanceOperation: z.object({
       inProgress: z.boolean().describe(
-        "Output only. [Output Only] Informs whether bulk instance operation is in progress.",
+        "Output only. Informs whether bulk instance operation is in progress.",
       ).optional(),
       lastProgressCheck: z.object({
         error: z.object({
@@ -839,21 +893,64 @@ const InputsSchema = z.object({
             "[Output Only] The array of errors encountered while processing this operation.",
           ).optional(),
         }).describe(
-          "Output only. [Output Only] Errors encountered during bulk instance operation.",
+          "Output only. Errors encountered during bulk instance operation.",
         ).optional(),
         timestamp: z.string().describe(
-          "Output only. [Output Only] Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
+          "Output only. Timestamp of the last progress check of bulk instance operation. Timestamp is in RFC3339 text format.",
         ).optional(),
       }).optional(),
     }).describe(
       "Bulk instance operation is the creation of VMs in a MIG when the targetSizePolicy.mode is set to BULK.",
     ).optional(),
+    currentInstanceStatuses: z.object({
+      deprovisioning: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have DEPROVISIONING status.",
+      ).optional(),
+      nonExistent: z.number().int().describe(
+        "Output only. The number of instances that have not been created yet or have been deleted. Includes only instances that would be shown in the listManagedInstances method and not all instances that have been deleted in the lifetime of the MIG. Does not include FlexStart instances that are waiting for the resources availability, they are considered as 'pending'.",
+      ).optional(),
+      pending: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have PENDING status, that is FlexStart instances that are waiting for resources. Instances that do not exist because of the other reasons are counted as 'non_existent'.",
+      ).optional(),
+      pendingStop: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have PENDING_STOP status.",
+      ).optional(),
+      provisioning: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have PROVISIONING status.",
+      ).optional(),
+      repairing: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have REPAIRING status.",
+      ).optional(),
+      running: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have RUNNING status.",
+      ).optional(),
+      staging: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have STAGING status.",
+      ).optional(),
+      stopped: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have STOPPED status.",
+      ).optional(),
+      stopping: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have STOPPING status.",
+      ).optional(),
+      suspended: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have SUSPENDED status.",
+      ).optional(),
+      suspending: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have SUSPENDING status.",
+      ).optional(),
+      terminated: z.number().int().describe(
+        "Output only. The number of instances in the managed instance group that have TERMINATED status.",
+      ).optional(),
+    }).describe(
+      "The list of instance statuses and the number of instances in this managed instance group that have the status. For more information about how to interpret each status check the instance lifecycle documentation. Currently only shown for TPU MIGs.",
+    ).optional(),
     isStable: z.boolean().describe(
-      "Output only. [Output Only] A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
+      "Output only. A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
     ).optional(),
     stateful: z.object({
       hasStatefulConfig: z.boolean().describe(
-        "Output only. [Output Only] A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
+        "Output only. A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
       ).optional(),
       perInstanceConfigs: z.object({
         allEffective: z.boolean().describe(
@@ -863,7 +960,7 @@ const InputsSchema = z.object({
     }).optional(),
     versionTarget: z.object({
       isReached: z.boolean().describe(
-        "Output only. [Output Only] A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
+        "Output only. A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified byversion field on Instance Group Manager.",
       ).optional(),
     }).optional(),
   }).optional(),
@@ -962,7 +1059,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regioninstancegroupmanagers",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1006,6 +1103,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/regioninstancetemplates.ts
+++ b/model/gcp/compute/extensions/models/regioninstancetemplates.ts
@@ -183,7 +183,7 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -497,6 +497,9 @@ const GlobalArgsSchema = z.object({
       ).optional(),
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
+      ).optional(),
+      serviceClassId: z.string().describe(
+        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
       ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
@@ -846,6 +849,7 @@ const StateSchema = z.object({
       nicType: z.string(),
       parentNicName: z.string(),
       queueCount: z.number(),
+      serviceClassId: z.string(),
       stackType: z.string(),
       subnetwork: z.string(),
       vlan: z.number(),
@@ -1014,7 +1018,7 @@ const InputsSchema = z.object({
       ).optional(),
       guestOsFeatures: z.array(z.object({
         type: z.unknown().describe(
-          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE For more information, see Enabling guest operating system features.",
+          "The ID of a supported feature. To add multiple values, use commas to separate values. Set to one or more of the following values: - VIRTIO_SCSI_MULTIQUEUE - WINDOWS - MULTI_IP_SUBNET - UEFI_COMPATIBLE - GVNIC - SEV_CAPABLE - SUSPEND_RESUME_COMPATIBLE - SEV_LIVE_MIGRATABLE_V2 - SEV_SNP_CAPABLE - TDX_CAPABLE - IDPF - SNP_SVSM_CAPABLE - CCA_CAPABLE For more information, see Enabling guest operating system features.",
         ).optional(),
       })).describe(
         "A list of features to enable on the guest operating system. Applicable only for bootable images. Read Enabling guest operating system features to see a list of available options.",
@@ -1329,6 +1333,9 @@ const InputsSchema = z.object({
       queueCount: z.number().int().describe(
         "The networking queue count that's specified by users for the network interface. Both Rx and Tx queues will be set to this number. It'll be empty if not specified by the users.",
       ).optional(),
+      serviceClassId: z.string().describe(
+        "Optional. Producer Service's Service class Id for the region of this network interface. Can only be used with network_attachment. It is not possible to use on its own however, network_attachment can be used without service_class_id.",
+      ).optional(),
       stackType: z.enum(["IPV4_IPV6", "IPV4_ONLY", "IPV6_ONLY"]).describe(
         "The stack type for this network interface. To assign only IPv4 addresses, use IPV4_ONLY. To assign both IPv4 and IPv6 addresses, useIPV4_IPV6. If not specified, IPV4_ONLY is used. This field can be both set at instance creation and update network interface operations.",
       ).optional(),
@@ -1531,7 +1538,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regioninstancetemplates",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -1575,6 +1582,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/regioninstantsnapshots.ts
+++ b/model/gcp/compute/extensions/models/regioninstantsnapshots.ts
@@ -150,6 +150,8 @@ const StateSchema = z.object({
   selfLinkWithId: z.string().optional(),
   sourceDisk: z.string().optional(),
   sourceDiskId: z.string().optional(),
+  sourceInstantSnapshotGroup: z.string().optional(),
+  sourceInstantSnapshotGroupId: z.string().optional(),
   status: z.string().optional(),
   zone: z.string().optional(),
 }).passthrough();
@@ -193,7 +195,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/regioninstantsnapshots",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -227,6 +229,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/compute/extensions/models/reservations.ts
+++ b/model/gcp/compute/extensions/models/reservations.ts
@@ -179,6 +179,10 @@ const GlobalArgsSchema = z.object({
   }).describe(
     "This reservation type is specified by total resource amounts (e.g. total count of CPUs) and can account for multiple instance SKUs. In other words, one can create instances of varying shapes against this reservation.",
   ).optional(),
+  confidentialComputeType: z.enum([
+    "CONFIDENTIAL_COMPUTE_TYPE_TDX",
+    "CONFIDENTIAL_COMPUTE_TYPE_UNSPECIFIED",
+  ]).optional(),
   deleteAfterDuration: z.object({
     nanos: z.number().int().describe(
       "Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented with a 0 `seconds` field and a positive `nanos` field. Must be from 0 to 999,999,999 inclusive.",
@@ -334,6 +338,7 @@ const StateSchema = z.object({
     workloadType: z.string(),
   }).optional(),
   commitment: z.string().optional(),
+  confidentialComputeType: z.string().optional(),
   creationTimestamp: z.string().optional(),
   deleteAfterDuration: z.object({
     nanos: z.number(),
@@ -474,6 +479,10 @@ const InputsSchema = z.object({
   }).describe(
     "This reservation type is specified by total resource amounts (e.g. total count of CPUs) and can account for multiple instance SKUs. In other words, one can create instances of varying shapes against this reservation.",
   ).optional(),
+  confidentialComputeType: z.enum([
+    "CONFIDENTIAL_COMPUTE_TYPE_TDX",
+    "CONFIDENTIAL_COMPUTE_TYPE_UNSPECIFIED",
+  ]).optional(),
   deleteAfterDuration: z.object({
     nanos: z.number().int().describe(
       "Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented with a 0 `seconds` field and a positive `nanos` field. Must be from 0 to 999,999,999 inclusive.",
@@ -610,7 +619,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/reservations",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -665,6 +674,11 @@ export const model = {
         return rest;
       },
     },
+    {
+      toVersion: "2026.04.07.1",
+      description: "Added: confidentialComputeType",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
   ],
   globalArguments: GlobalArgsSchema,
   inputsSchema: InputsSchema,
@@ -696,6 +710,9 @@ export const model = {
         }
         if (g["aggregateReservation"] !== undefined) {
           body["aggregateReservation"] = g["aggregateReservation"];
+        }
+        if (g["confidentialComputeType"] !== undefined) {
+          body["confidentialComputeType"] = g["confidentialComputeType"];
         }
         if (g["deleteAfterDuration"] !== undefined) {
           body["deleteAfterDuration"] = g["deleteAfterDuration"];
@@ -827,6 +844,9 @@ export const model = {
         }
         if (g["aggregateReservation"] !== undefined) {
           body["aggregateReservation"] = g["aggregateReservation"];
+        }
+        if (g["confidentialComputeType"] !== undefined) {
+          body["confidentialComputeType"] = g["confidentialComputeType"];
         }
         if (g["deleteAfterDuration"] !== undefined) {
           body["deleteAfterDuration"] = g["deleteAfterDuration"];

--- a/model/gcp/compute/extensions/models/snapshots.ts
+++ b/model/gcp/compute/extensions/models/snapshots.ts
@@ -199,6 +199,7 @@ const StateSchema = z.object({
   params: z.object({
     resourceManagerTags: z.record(z.string(), z.unknown()),
   }).optional(),
+  region: z.string().optional(),
   satisfiesPzi: z.boolean().optional(),
   satisfiesPzs: z.boolean().optional(),
   selfLink: z.string().optional(),
@@ -209,6 +210,8 @@ const StateSchema = z.object({
     rsaEncryptedKey: z.string(),
     sha256: z.string(),
   }).optional(),
+  snapshotGroupId: z.string().optional(),
+  snapshotGroupName: z.string().optional(),
   snapshotType: z.string().optional(),
   sourceDisk: z.string().optional(),
   sourceDiskEncryptionKey: z.object({
@@ -340,7 +343,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/snapshots",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.03.31.1",
@@ -384,6 +387,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.2",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
@@ -622,6 +630,53 @@ export const model = {
             "parameters": {
               "project": { "location": "path", "required": true },
               "resource": { "location": "path", "required": true },
+            },
+          },
+          params,
+          body,
+        );
+        return { result };
+      },
+    },
+    update_kms_key: {
+      description: "update kms key",
+      arguments: z.object({
+        kmsKeyName: z.any().optional(),
+      }),
+      execute: async (args: Record<string, unknown>, context: any) => {
+        const g = context.globalArgs;
+        const projectId = await getProjectId();
+        const params: Record<string, string> = { project: projectId };
+        const content = await context.dataRepository.getContent(
+          context.modelType,
+          context.modelId,
+          (g.name?.toString() ?? "current").replace(/[\/\\]/g, "_").replace(
+            /\.\./g,
+            "_",
+          ).replace(/\0/g, ""),
+        );
+        if (!content) {
+          throw new Error("No existing state found - run create or get first");
+        }
+        const existing = JSON.parse(new TextDecoder().decode(content));
+        params["snapshot"] = existing["name"]?.toString() ??
+          g["name"]?.toString() ?? "";
+        const body: Record<string, unknown> = {};
+        if (args["kmsKeyName"] !== undefined) {
+          body["kmsKeyName"] = args["kmsKeyName"];
+        }
+        const result = await createResource(
+          BASE_URL,
+          {
+            "id": "compute.snapshots.updateKmsKey",
+            "path":
+              "projects/{project}/global/snapshots/{snapshot}/updateKmsKey",
+            "httpMethod": "POST",
+            "parameterOrder": ["project", "snapshot"],
+            "parameters": {
+              "project": { "location": "path", "required": true },
+              "requestId": { "location": "query" },
+              "snapshot": { "location": "path", "required": true },
             },
           },
           params,

--- a/model/gcp/compute/extensions/models/snapshotsettings.ts
+++ b/model/gcp/compute/extensions/models/snapshotsettings.ts
@@ -53,6 +53,19 @@ const GlobalArgsSchema = z.object({
   name: z.string().describe(
     "Instance name for this resource (used as the unique identifier in the factory pattern)",
   ),
+  accessLocation: z.object({
+    locations: z.record(
+      z.string(),
+      z.object({
+        region: z.string().describe("Accessible region name").optional(),
+      }),
+    ).describe(
+      "List of regions that can restore a regional snapshot from the current region",
+    ).optional(),
+    policy: z.enum(["ALL_REGIONS", "POLICY_UNSPECIFIED", "SPECIFIC_REGIONS"])
+      .describe("Policy of which location is allowed to access snapshot.")
+      .optional(),
+  }).optional(),
   storageLocation: z.object({
     locations: z.record(
       z.string(),
@@ -74,6 +87,10 @@ const GlobalArgsSchema = z.object({
 });
 
 const StateSchema = z.object({
+  accessLocation: z.object({
+    locations: z.record(z.string(), z.unknown()),
+    policy: z.string(),
+  }).optional(),
   storageLocation: z.object({
     locations: z.record(z.string(), z.unknown()),
     policy: z.string(),
@@ -84,6 +101,19 @@ type StateData = z.infer<typeof StateSchema>;
 
 const InputsSchema = z.object({
   name: z.string().optional(),
+  accessLocation: z.object({
+    locations: z.record(
+      z.string(),
+      z.object({
+        region: z.string().describe("Accessible region name").optional(),
+      }),
+    ).describe(
+      "List of regions that can restore a regional snapshot from the current region",
+    ).optional(),
+    policy: z.enum(["ALL_REGIONS", "POLICY_UNSPECIFIED", "SPECIFIC_REGIONS"])
+      .describe("Policy of which location is allowed to access snapshot.")
+      .optional(),
+  }).optional(),
   storageLocation: z.object({
     locations: z.record(
       z.string(),
@@ -106,7 +136,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/compute/snapshotsettings",
-  version: "2026.04.04.2",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -145,6 +175,11 @@ export const model = {
         const { accessLocation: _accessLocation, ...rest } = old;
         return rest;
       },
+    },
+    {
+      toVersion: "2026.04.07.1",
+      description: "Added: accessLocation",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
     },
   ],
   globalArguments: GlobalArgsSchema,
@@ -196,6 +231,9 @@ export const model = {
         ).replace(/\.\./g, "_").replace(/\0/g, "");
         const params: Record<string, string> = { project: projectId };
         const body: Record<string, unknown> = {};
+        if (g["accessLocation"] !== undefined) {
+          body["accessLocation"] = g["accessLocation"];
+        }
         if (g["storageLocation"] !== undefined) {
           body["storageLocation"] = g["storageLocation"];
         }

--- a/model/gcp/compute/manifest.yaml
+++ b/model/gcp/compute/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/gcp/compute"
-version: "2026.04.04.2"
+version: "2026.04.07.1"
 description: "Google Cloud compute infrastructure models"
 labels:
   - gcp
@@ -40,6 +40,7 @@ models:
   - instances.ts
   - instancesettings.ts
   - instancetemplates.ts
+  - instantsnapshotgroups.ts
   - instantsnapshots.ts
   - interconnectattachmentgroups.ts
   - interconnectattachments.ts
@@ -67,6 +68,7 @@ models:
   - publicadvertisedprefixes.ts
   - publicdelegatedprefixes.ts
   - regionautoscalers.ts
+  - regionbackendbuckets.ts
   - regionbackendservices.ts
   - regioncommitments.ts
   - regioncompositehealthchecks.ts
@@ -76,15 +78,19 @@ models:
   - regionhealthchecks.ts
   - regionhealthcheckservices.ts
   - regionhealthsources.ts
+  - regioninstancegroupmanagerresizerequests.ts
   - regioninstancegroupmanagers.ts
   - regioninstancegroups.ts
   - regioninstancetemplates.ts
+  - regioninstantsnapshotgroups.ts
   - regioninstantsnapshots.ts
   - regionnetworkendpointgroups.ts
   - regionnetworkfirewallpolicies.ts
   - regionnotificationendpoints.ts
   - regions.ts
   - regionsecuritypolicies.ts
+  - regionsnapshots.ts
+  - regionsnapshotsettings.ts
   - regionsslcertificates.ts
   - regionsslpolicies.ts
   - regiontargethttpproxies.ts
@@ -121,6 +127,7 @@ models:
   - vpntunnels.ts
   - wiregroups.ts
   - zones.ts
+  - zonevmextensionpolicies.ts
 additionalFiles:
   - LICENSE.txt
   - README.md

--- a/model/gcp/health/extensions/models/users_datatypes_datapoints.ts
+++ b/model/gcp/health/extensions/models/users_datatypes_datapoints.ts
@@ -41,9 +41,6 @@ const PATCH_CONFIG = {
       "location": "path",
       "required": true,
     },
-    "updateMask": {
-      "location": "query",
-    },
   },
 } as const;
 
@@ -689,13 +686,13 @@ const GlobalArgsSchema = z.object({
   dataSource: z.object({
     application: z.object({
       googleWebClientId: z.string().describe(
-        "Output only. Captures the client ID of the entity that recorded the data.",
+        "Output only. The Google OAuth 2.0 client ID of the web application or service that recorded the data. This is the client ID used during the Google OAuth flow to obtain user credentials. This field is system-populated when the data is uploaded from Google Web API.",
       ).optional(),
       packageName: z.string().describe(
-        "Output only. A unique ID from an external data source. A unique identifier of the mobile application, e.g. `com.google.fitbit`",
+        "Output only. A unique identifier for the mobile application that was the source of the data. This is typically the application's package name on Android (e.g., `com.google.fitbit`) or the bundle ID on iOS. This field is informational and helps trace data origin. This field is system-populated when the data is uploaded from the Fitbit mobile application, Health Connect or Health Kit.",
       ).optional(),
       webClientId: z.string().describe(
-        "Output only. Captures the client ID of the web application that recorded the data.",
+        "Output only. The client ID of the application that recorded the data. This ID is a legacy Fitbit API client ID, which is different from a Google OAuth client ID. Example format: `ABC123`. This field is system-populated and used for tracing data from legacy Fitbit API integrations. This field is system-populated when the data is uploaded from a legacy Fitbit API integration.",
       ).optional(),
     }).describe(
       "Optional metadata for the application that provided this data.",
@@ -1515,7 +1512,7 @@ const GlobalArgsSchema = z.object({
     ).optional(),
   }).describe("Holds information about a user logged hydration.").optional(),
   name: z.string().describe(
-    "Identifier. Data point name, only supported for the subset of identifiable data types. For the majority of the data types, individual data points do not need to be identified and this field would be empty. Format: `users/{user}/dataTypes/{data_type}/dataPoints/{data_point}` Example: `users/abcd1234/dataTypes/sleep/dataPoints/a1b2c3d4-e5f6-7890-1234-567890abcdef` The `{user}` ID is a system-generated identifier, as described in Profile.encoded_id. The `{data_type}` ID corresponds to the kebab-case version of the field names in the DataPoint data union field, e.g. `total-calories` for the `total_calories` field. The `{data_point}` ID can be client-provided or system-generated. If client-provided, it must be a string of 4-63 characters, containing only lowercase letters, numbers, and hyphens.",
+    "Identifier. Data point name, only supported for the subset of identifiable data types. For the majority of the data types, individual data points do not need to be identified and this field would be empty. Format: `users/{user}/dataTypes/{data_type}/dataPoints/{data_point}` Example: `users/abcd1234/dataTypes/sleep/dataPoints/a1b2c3d4-e5f6-7890-1234-567890abcdef` The `{user}` ID is a system-generated identifier, as described in Identity.health_user_id. The `{data_type}` ID corresponds to the kebab-case version of the field names in the DataPoint data union field, e.g. `total-calories` for the `total_calories` field. The `{data_point}` ID can be client-provided or system-generated. If client-provided, it must be a string of 4-63 characters, containing only lowercase letters, numbers, and hyphens.",
   ).optional(),
   oxygenSaturation: z.object({
     percentage: z.number().describe(
@@ -3747,13 +3744,13 @@ const InputsSchema = z.object({
   dataSource: z.object({
     application: z.object({
       googleWebClientId: z.string().describe(
-        "Output only. Captures the client ID of the entity that recorded the data.",
+        "Output only. The Google OAuth 2.0 client ID of the web application or service that recorded the data. This is the client ID used during the Google OAuth flow to obtain user credentials. This field is system-populated when the data is uploaded from Google Web API.",
       ).optional(),
       packageName: z.string().describe(
-        "Output only. A unique ID from an external data source. A unique identifier of the mobile application, e.g. `com.google.fitbit`",
+        "Output only. A unique identifier for the mobile application that was the source of the data. This is typically the application's package name on Android (e.g., `com.google.fitbit`) or the bundle ID on iOS. This field is informational and helps trace data origin. This field is system-populated when the data is uploaded from the Fitbit mobile application, Health Connect or Health Kit.",
       ).optional(),
       webClientId: z.string().describe(
-        "Output only. Captures the client ID of the web application that recorded the data.",
+        "Output only. The client ID of the application that recorded the data. This ID is a legacy Fitbit API client ID, which is different from a Google OAuth client ID. Example format: `ABC123`. This field is system-populated and used for tracing data from legacy Fitbit API integrations. This field is system-populated when the data is uploaded from a legacy Fitbit API integration.",
       ).optional(),
     }).describe(
       "Optional metadata for the application that provided this data.",
@@ -4573,7 +4570,7 @@ const InputsSchema = z.object({
     ).optional(),
   }).describe("Holds information about a user logged hydration.").optional(),
   name: z.string().describe(
-    "Identifier. Data point name, only supported for the subset of identifiable data types. For the majority of the data types, individual data points do not need to be identified and this field would be empty. Format: `users/{user}/dataTypes/{data_type}/dataPoints/{data_point}` Example: `users/abcd1234/dataTypes/sleep/dataPoints/a1b2c3d4-e5f6-7890-1234-567890abcdef` The `{user}` ID is a system-generated identifier, as described in Profile.encoded_id. The `{data_type}` ID corresponds to the kebab-case version of the field names in the DataPoint data union field, e.g. `total-calories` for the `total_calories` field. The `{data_point}` ID can be client-provided or system-generated. If client-provided, it must be a string of 4-63 characters, containing only lowercase letters, numbers, and hyphens.",
+    "Identifier. Data point name, only supported for the subset of identifiable data types. For the majority of the data types, individual data points do not need to be identified and this field would be empty. Format: `users/{user}/dataTypes/{data_type}/dataPoints/{data_point}` Example: `users/abcd1234/dataTypes/sleep/dataPoints/a1b2c3d4-e5f6-7890-1234-567890abcdef` The `{user}` ID is a system-generated identifier, as described in Identity.health_user_id. The `{data_type}` ID corresponds to the kebab-case version of the field names in the DataPoint data union field, e.g. `total-calories` for the `total_calories` field. The `{data_point}` ID can be client-provided or system-generated. If client-provided, it must be a string of 4-63 characters, containing only lowercase letters, numbers, and hyphens.",
   ).optional(),
   oxygenSaturation: z.object({
     percentage: z.number().describe(
@@ -5342,7 +5339,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/health/users-datatypes-datapoints",
-  version: "2026.04.04.1",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.2",
@@ -5371,6 +5368,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/health/manifest.yaml
+++ b/model/gcp/health/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/gcp/health"
-version: "2026.04.04.1"
+version: "2026.04.07.1"
 description: "Google Cloud health infrastructure models"
 labels:
   - gcp

--- a/model/gcp/mybusinessbusinessinformation/extensions/models/accounts.ts
+++ b/model/gcp/mybusinessbusinessinformation/extensions/models/accounts.ts
@@ -182,7 +182,7 @@ const GlobalArgsSchema = z.object({
       "Output only. The location resource that this location duplicates.",
     ).optional(),
     hasGoogleUpdated: z.boolean().describe(
-      "Output only. Indicates whether the place ID associated with this location has updates that need to be updated or rejected by the client. If this boolean is set, you should call the `getGoogleUpdated` method to lookup information that's needs to be verified.",
+      "Output only. Indicates whether the place ID associated with this location has updates that need to be updated or rejected by the client. If this boolean is set, you should call the `getGoogleUpdated` method to look up information that's needs to be verified.",
     ).optional(),
     hasPendingEdits: z.boolean().describe(
       "Output only. Indicates whether any of this Location's properties are in the edit pending state.",
@@ -455,7 +455,7 @@ const GlobalArgsSchema = z.object({
         "Label to be used when displaying the price list, section, or item.",
       ).optional(),
     }).describe(
-      "Represents a free-form service offered by the merchant. These are services that are not exposed as part of our structure service data. The merchant manually enters the names for of such services via a geomerchant surface.",
+      "Represents a free-form service offered by the merchant. These are services that are not exposed as part of our structure service data. The merchant manually enters the names for such services using a geomerchant surface.",
     ).optional(),
     price: z.object({
       currencyCode: z.string().describe(
@@ -919,7 +919,7 @@ const InputsSchema = z.object({
       "Output only. The location resource that this location duplicates.",
     ).optional(),
     hasGoogleUpdated: z.boolean().describe(
-      "Output only. Indicates whether the place ID associated with this location has updates that need to be updated or rejected by the client. If this boolean is set, you should call the `getGoogleUpdated` method to lookup information that's needs to be verified.",
+      "Output only. Indicates whether the place ID associated with this location has updates that need to be updated or rejected by the client. If this boolean is set, you should call the `getGoogleUpdated` method to look up information that's needs to be verified.",
     ).optional(),
     hasPendingEdits: z.boolean().describe(
       "Output only. Indicates whether any of this Location's properties are in the edit pending state.",
@@ -1192,7 +1192,7 @@ const InputsSchema = z.object({
         "Label to be used when displaying the price list, section, or item.",
       ).optional(),
     }).describe(
-      "Represents a free-form service offered by the merchant. These are services that are not exposed as part of our structure service data. The merchant manually enters the names for of such services via a geomerchant surface.",
+      "Represents a free-form service offered by the merchant. These are services that are not exposed as part of our structure service data. The merchant manually enters the names for such services using a geomerchant surface.",
     ).optional(),
     price: z.object({
       currencyCode: z.string().describe(
@@ -1344,7 +1344,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/mybusinessbusinessinformation/accounts",
-  version: "2026.04.04.1",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -1373,6 +1373,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/mybusinessbusinessinformation/extensions/models/locations.ts
+++ b/model/gcp/mybusinessbusinessinformation/extensions/models/locations.ts
@@ -187,7 +187,7 @@ const GlobalArgsSchema = z.object({
       "Output only. The location resource that this location duplicates.",
     ).optional(),
     hasGoogleUpdated: z.boolean().describe(
-      "Output only. Indicates whether the place ID associated with this location has updates that need to be updated or rejected by the client. If this boolean is set, you should call the `getGoogleUpdated` method to lookup information that's needs to be verified.",
+      "Output only. Indicates whether the place ID associated with this location has updates that need to be updated or rejected by the client. If this boolean is set, you should call the `getGoogleUpdated` method to look up information that's needs to be verified.",
     ).optional(),
     hasPendingEdits: z.boolean().describe(
       "Output only. Indicates whether any of this Location's properties are in the edit pending state.",
@@ -460,7 +460,7 @@ const GlobalArgsSchema = z.object({
         "Label to be used when displaying the price list, section, or item.",
       ).optional(),
     }).describe(
-      "Represents a free-form service offered by the merchant. These are services that are not exposed as part of our structure service data. The merchant manually enters the names for of such services via a geomerchant surface.",
+      "Represents a free-form service offered by the merchant. These are services that are not exposed as part of our structure service data. The merchant manually enters the names for such services using a geomerchant surface.",
     ).optional(),
     price: z.object({
       currencyCode: z.string().describe(
@@ -918,7 +918,7 @@ const InputsSchema = z.object({
       "Output only. The location resource that this location duplicates.",
     ).optional(),
     hasGoogleUpdated: z.boolean().describe(
-      "Output only. Indicates whether the place ID associated with this location has updates that need to be updated or rejected by the client. If this boolean is set, you should call the `getGoogleUpdated` method to lookup information that's needs to be verified.",
+      "Output only. Indicates whether the place ID associated with this location has updates that need to be updated or rejected by the client. If this boolean is set, you should call the `getGoogleUpdated` method to look up information that's needs to be verified.",
     ).optional(),
     hasPendingEdits: z.boolean().describe(
       "Output only. Indicates whether any of this Location's properties are in the edit pending state.",
@@ -1191,7 +1191,7 @@ const InputsSchema = z.object({
         "Label to be used when displaying the price list, section, or item.",
       ).optional(),
     }).describe(
-      "Represents a free-form service offered by the merchant. These are services that are not exposed as part of our structure service data. The merchant manually enters the names for of such services via a geomerchant surface.",
+      "Represents a free-form service offered by the merchant. These are services that are not exposed as part of our structure service data. The merchant manually enters the names for such services using a geomerchant surface.",
     ).optional(),
     price: z.object({
       currencyCode: z.string().describe(
@@ -1337,7 +1337,7 @@ const InputsSchema = z.object({
 
 export const model = {
   type: "@swamp/gcp/mybusinessbusinessinformation/locations",
-  version: "2026.04.04.1",
+  version: "2026.04.07.1",
   upgrades: [
     {
       toVersion: "2026.04.01.1",
@@ -1366,6 +1366,11 @@ export const model = {
     },
     {
       toVersion: "2026.04.04.1",
+      description: "No schema changes",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.04.07.1",
       description: "No schema changes",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },

--- a/model/gcp/mybusinessbusinessinformation/manifest.yaml
+++ b/model/gcp/mybusinessbusinessinformation/manifest.yaml
@@ -1,7 +1,7 @@
 # Auto-generated manifest. Re-generate with the appropriate deno task.
 manifestVersion: 1
 name: "@swamp/gcp/mybusinessbusinessinformation"
-version: "2026.04.04.1"
+version: "2026.04.07.1"
 description: "Google Cloud mybusinessbusinessinformation infrastructure models"
 labels:
   - gcp


### PR DESCRIPTION
## Summary

Automated regeneration of extension models from upstream provider schemas.

### Changes

- **aws**: 11 files changed
- **gcp**: 34 files changed


### Schema Sources

- **AWS**: CloudFormation Resource Schema
- **GCP**: Google Discovery Documents
- **Hetzner**: Hetzner Cloud OpenAPI spec
- **DigitalOcean**: DigitalOcean OpenAPI spec

### Review Notes

- Files under `model/` are auto-generated — review the `manifest.yaml` diffs for version changes
- CalVer versioning with content-based change detection ensures versions only bump when content changes
- Publishing happens automatically when this PR is merged (via the publish workflow)

